### PR TITLE
10.1.x rector ConfigEntity

### DIFF
--- a/core/composer.json
+++ b/core/composer.json
@@ -44,7 +44,7 @@
         "psr/log": "^3.0",
         "mck89/peast": "^1.14",
         "sebastian/diff": "^4",
-        "palantirnet/drupal-rector": "dev-action-attributes"
+        "palantirnet/drupal-rector": "dev-feature/annotation-configentitytype"
     },
     "conflict": {
         "drush/drush": "<8.1.10"
@@ -114,12 +114,6 @@
     },
     "suggest": {
         "ext-zip": "Needed to extend the plugin.manager.archiver service capability with the handling of files in the ZIP format."
-    },
-    "repositories": {
-        "palantirnet/drupal-rector" : {
-            "type": "vcs",
-            "url": "https://github.com/skilld-labs/drupal-rector"
-        }
     },
     "extra": {
         "drupal-scaffold": {

--- a/core/lib/Drupal/Core/Datetime/Entity/DateFormat.php
+++ b/core/lib/Drupal/Core/Datetime/Entity/DateFormat.php
@@ -8,27 +8,8 @@ use Drupal\Core\Datetime\DateFormatInterface;
 
 /**
  * Defines the Date Format configuration entity class.
- *
- * @ConfigEntityType(
- *   id = "date_format",
- *   label = @Translation("Date format"),
- *   handlers = {
- *     "access" = "Drupal\system\DateFormatAccessControlHandler",
- *   },
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   },
- *   admin_permission = "administer site configuration",
- *   list_cache_tags = { "rendered" },
- *   config_export = {
- *     "id",
- *     "label",
- *     "locked",
- *     "pattern",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'date_format', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Date format'), handlers: ['access' => 'Drupal\system\DateFormatAccessControlHandler'], entity_keys: ['id' => 'id', 'label' => 'label'], admin_permission: 'administer site configuration', list_cache_tags: ['rendered'], config_export: ['id', 'label', 'locked', 'pattern'])]
 class DateFormat extends ConfigEntityBase implements DateFormatInterface {
 
   /**

--- a/core/lib/Drupal/Core/Entity/Entity/EntityFormDisplay.php
+++ b/core/lib/Drupal/Core/Entity/Entity/EntityFormDisplay.php
@@ -17,27 +17,8 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
  *
  * Contains widget options for all components of an entity form in a given
  * form mode.
- *
- * @ConfigEntityType(
- *   id = "entity_form_display",
- *   label = @Translation("Entity form display"),
- *   entity_keys = {
- *     "id" = "id",
- *     "status" = "status"
- *   },
- *   handlers = {
- *     "access" = "\Drupal\Core\Entity\Entity\Access\EntityFormDisplayAccessControlHandler",
- *   },
- *   config_export = {
- *     "id",
- *     "targetEntityType",
- *     "bundle",
- *     "mode",
- *     "content",
- *     "hidden",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'entity_form_display', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Entity form display'), entity_keys: ['id' => 'id', 'status' => 'status'], handlers: ['access' => '\Drupal\Core\Entity\Entity\Access\EntityFormDisplayAccessControlHandler'], config_export: ['id', 'targetEntityType', 'bundle', 'mode', 'content', 'hidden'])]
 class EntityFormDisplay extends EntityDisplayBase implements EntityFormDisplayInterface {
 
   /**

--- a/core/lib/Drupal/Core/Entity/Entity/EntityFormMode.php
+++ b/core/lib/Drupal/Core/Entity/Entity/EntityFormMode.php
@@ -21,22 +21,8 @@ use Drupal\Core\Entity\EntityFormModeInterface;
  *
  * @see \Drupal\Core\Entity\EntityDisplayRepositoryInterface::getAllFormModes()
  * @see \Drupal\Core\Entity\EntityDisplayRepositoryInterface::getFormModes()
- *
- * @ConfigEntityType(
- *   id = "entity_form_mode",
- *   label = @Translation("Form mode"),
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "targetEntityType",
- *     "cache",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'entity_form_mode', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Form mode'), entity_keys: ['id' => 'id', 'label' => 'label'], config_export: ['id', 'label', 'targetEntityType', 'cache'])]
 class EntityFormMode extends EntityDisplayModeBase implements EntityFormModeInterface {
 
 }

--- a/core/lib/Drupal/Core/Entity/Entity/EntityViewDisplay.php
+++ b/core/lib/Drupal/Core/Entity/Entity/EntityViewDisplay.php
@@ -16,27 +16,8 @@ use Drupal\Core\TypedData\TranslatableInterface as TranslatableDataInterface;
  *
  * Contains display options for all components of a rendered entity in a given
  * view mode.
- *
- * @ConfigEntityType(
- *   id = "entity_view_display",
- *   label = @Translation("Entity view display"),
- *   entity_keys = {
- *     "id" = "id",
- *     "status" = "status"
- *   },
- *   handlers = {
- *     "access" = "\Drupal\Core\Entity\Entity\Access\EntityViewDisplayAccessControlHandler",
- *   },
- *   config_export = {
- *     "id",
- *     "targetEntityType",
- *     "bundle",
- *     "mode",
- *     "content",
- *     "hidden",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'entity_view_display', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Entity view display'), entity_keys: ['id' => 'id', 'status' => 'status'], handlers: ['access' => '\Drupal\Core\Entity\Entity\Access\EntityViewDisplayAccessControlHandler'], config_export: ['id', 'targetEntityType', 'bundle', 'mode', 'content', 'hidden'])]
 class EntityViewDisplay extends EntityDisplayBase implements EntityViewDisplayInterface {
 
   /**

--- a/core/lib/Drupal/Core/Entity/Entity/EntityViewMode.php
+++ b/core/lib/Drupal/Core/Entity/Entity/EntityViewMode.php
@@ -23,22 +23,8 @@ use Drupal\Core\Entity\EntityViewModeInterface;
  * @see \Drupal\Core\Entity\EntityDisplayRepositoryInterface::getAllViewModes()
  * @see \Drupal\Core\Entity\EntityDisplayRepositoryInterface::getViewModes()
  * @see hook_entity_view_mode_info_alter()
- *
- * @ConfigEntityType(
- *   id = "entity_view_mode",
- *   label = @Translation("View mode"),
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "targetEntityType",
- *     "cache",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'entity_view_mode', label: new Drupal\Core\StringTranslation\TranslatableMarkup('View mode'), entity_keys: ['id' => 'id', 'label' => 'label'], config_export: ['id', 'label', 'targetEntityType', 'cache'])]
 class EntityViewMode extends EntityDisplayModeBase implements EntityViewModeInterface {
 
 }

--- a/core/lib/Drupal/Core/Field/Entity/BaseFieldOverride.php
+++ b/core/lib/Drupal/Core/Field/Entity/BaseFieldOverride.php
@@ -11,35 +11,8 @@ use Drupal\Core\Field\FieldException;
  * Defines the base field override entity.
  *
  * Allows base fields to be overridden on the bundle level.
- *
- * @ConfigEntityType(
- *   id = "base_field_override",
- *   label = @Translation("Base field override"),
- *   handlers = {
- *     "storage" = "Drupal\Core\Field\BaseFieldOverrideStorage",
- *     "access" = "Drupal\Core\Field\BaseFieldOverrideAccessControlHandler",
- *   },
- *   config_prefix = "base_field_override",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   },
- *   config_export = {
- *     "id",
- *     "field_name",
- *     "entity_type",
- *     "bundle",
- *     "label",
- *     "description",
- *     "required",
- *     "translatable",
- *     "default_value",
- *     "default_value_callback",
- *     "settings",
- *     "field_type",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'base_field_override', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Base field override'), handlers: ['storage' => 'Drupal\Core\Field\BaseFieldOverrideStorage', 'access' => 'Drupal\Core\Field\BaseFieldOverrideAccessControlHandler'], config_prefix: 'base_field_override', entity_keys: ['id' => 'id', 'label' => 'label'], config_export: ['id', 'field_name', 'entity_type', 'bundle', 'label', 'description', 'required', 'translatable', 'default_value', 'default_value_callback', 'settings', 'field_type'])]
 class BaseFieldOverride extends FieldConfigBase {
 
   /**

--- a/core/modules/block/src/Entity/Block.php
+++ b/core/modules/block/src/Entity/Block.php
@@ -13,52 +13,8 @@ use Drupal\Core\Entity\EntityStorageInterface;
 
 /**
  * Defines a Block configuration entity class.
- *
- * @ConfigEntityType(
- *   id = "block",
- *   label = @Translation("Block"),
- *   label_collection = @Translation("Blocks"),
- *   label_singular = @Translation("block"),
- *   label_plural = @Translation("blocks"),
- *   label_count = @PluralTranslation(
- *     singular = "@count block",
- *     plural = "@count blocks",
- *   ),
- *   handlers = {
- *     "access" = "Drupal\block\BlockAccessControlHandler",
- *     "view_builder" = "Drupal\block\BlockViewBuilder",
- *     "list_builder" = "Drupal\block\BlockListBuilder",
- *     "form" = {
- *       "default" = "Drupal\block\BlockForm",
- *       "delete" = "Drupal\block\Form\BlockDeleteForm"
- *     }
- *   },
- *   admin_permission = "administer blocks",
- *   entity_keys = {
- *     "id" = "id",
- *     "status" = "status"
- *   },
- *   links = {
- *     "delete-form" = "/admin/structure/block/manage/{block}/delete",
- *     "edit-form" = "/admin/structure/block/manage/{block}",
- *     "enable" = "/admin/structure/block/manage/{block}/enable",
- *     "disable" = "/admin/structure/block/manage/{block}/disable",
- *   },
- *   config_export = {
- *     "id",
- *     "theme",
- *     "region",
- *     "weight",
- *     "provider",
- *     "plugin",
- *     "settings",
- *     "visibility",
- *   },
- *   lookup_keys = {
- *     "theme"
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'block', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Block'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Blocks'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('block'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('blocks'), label_count: ['singular' => '@count block', 'plural' => '@count blocks'], handlers: ['access' => 'Drupal\block\BlockAccessControlHandler', 'view_builder' => 'Drupal\block\BlockViewBuilder', 'list_builder' => 'Drupal\block\BlockListBuilder', 'form' => ['default' => 'Drupal\block\BlockForm', 'delete' => 'Drupal\block\Form\BlockDeleteForm']], admin_permission: 'administer blocks', entity_keys: ['id' => 'id', 'status' => 'status'], links: ['delete-form' => '/admin/structure/block/manage/{block}/delete', 'edit-form' => '/admin/structure/block/manage/{block}', 'enable' => '/admin/structure/block/manage/{block}/enable', 'disable' => '/admin/structure/block/manage/{block}/disable'], config_export: ['id', 'theme', 'region', 'weight', 'provider', 'plugin', 'settings', 'visibility'], lookup_keys: ['theme'])]
 class Block extends ConfigEntityBase implements BlockInterface, EntityWithPluginCollectionInterface {
 
   /**

--- a/core/modules/block_content/src/Entity/BlockContent.php
+++ b/core/modules/block_content/src/Entity/BlockContent.php
@@ -12,78 +12,8 @@ use Drupal\user\UserInterface;
 
 /**
  * Defines the content block entity class.
- *
- * @ContentEntityType(
- *   id = "block_content",
- *   label = @Translation("Content block"),
- *   label_collection = @Translation("Content blocks"),
- *   label_singular = @Translation("content block"),
- *   label_plural = @Translation("content blocks"),
- *   label_count = @PluralTranslation(
- *     singular = "@count content block",
- *     plural = "@count content blocks",
- *   ),
- *   bundle_label = @Translation("Block type"),
- *   handlers = {
- *     "storage" = "Drupal\Core\Entity\Sql\SqlContentEntityStorage",
- *     "access" = "Drupal\block_content\BlockContentAccessControlHandler",
- *     "list_builder" = "Drupal\block_content\BlockContentListBuilder",
- *     "view_builder" = "Drupal\block_content\BlockContentViewBuilder",
- *     "views_data" = "Drupal\block_content\BlockContentViewsData",
- *     "form" = {
- *       "add" = "Drupal\block_content\BlockContentForm",
- *       "edit" = "Drupal\block_content\BlockContentForm",
- *       "delete" = "Drupal\block_content\Form\BlockContentDeleteForm",
- *       "default" = "Drupal\block_content\BlockContentForm",
- *       "revision-delete" = \Drupal\Core\Entity\Form\RevisionDeleteForm::class,
- *       "revision-revert" = \Drupal\Core\Entity\Form\RevisionRevertForm::class,
- *     },
- *     "route_provider" = {
- *       "revision" = \Drupal\Core\Entity\Routing\RevisionHtmlRouteProvider::class,
- *     },
- *     "translation" = "Drupal\block_content\BlockContentTranslationHandler"
- *   },
- *   admin_permission = "administer block content",
- *   base_table = "block_content",
- *   revision_table = "block_content_revision",
- *   data_table = "block_content_field_data",
- *   revision_data_table = "block_content_field_revision",
- *   show_revision_ui = TRUE,
- *   links = {
- *     "canonical" = "/admin/content/block/{block_content}",
- *     "delete-form" = "/admin/content/block/{block_content}/delete",
- *     "edit-form" = "/admin/content/block/{block_content}",
- *     "collection" = "/admin/content/block",
- *     "create" = "/block",
- *     "revision-delete-form" = "/admin/content/block/{block_content}/revision/{block_content_revision}/delete",
- *     "revision-revert-form" = "/admin/content/block/{block_content}/revision/{block_content_revision}/revert",
- *     "version-history" = "/admin/content/block/{block_content}/revisions",
- *   },
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "revision" = "revision_id",
- *     "bundle" = "type",
- *     "label" = "info",
- *     "langcode" = "langcode",
- *     "uuid" = "uuid",
- *     "published" = "status",
- *   },
- *   revision_metadata_keys = {
- *     "revision_user" = "revision_user",
- *     "revision_created" = "revision_created",
- *     "revision_log_message" = "revision_log"
- *   },
- *   bundle_entity_type = "block_content_type",
- *   field_ui_base_route = "entity.block_content_type.edit_form",
- *   render_cache = FALSE,
- * )
- *
- * Note that render caching of block_content entities is disabled because they
- * are always rendered as blocks, and blocks already have their own render
- * caching.
- * See https://www.drupal.org/node/2284917#comment-9132521 for more information.
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'block_content', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Content block'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Content blocks'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('content block'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('content blocks'), label_count: ['singular' => '@count content block', 'plural' => '@count content blocks'], bundle_label: new Drupal\Core\StringTranslation\TranslatableMarkup('Block type'), handlers: ['storage' => 'Drupal\Core\Entity\Sql\SqlContentEntityStorage', 'access' => 'Drupal\block_content\BlockContentAccessControlHandler', 'list_builder' => 'Drupal\block_content\BlockContentListBuilder', 'view_builder' => 'Drupal\block_content\BlockContentViewBuilder', 'views_data' => 'Drupal\block_content\BlockContentViewsData', 'form' => ['add' => 'Drupal\block_content\BlockContentForm', 'edit' => 'Drupal\block_content\BlockContentForm', 'delete' => 'Drupal\block_content\Form\BlockContentDeleteForm', 'default' => 'Drupal\block_content\BlockContentForm', 'revision-delete' => \Drupal\Core\Entity\Form\RevisionDeleteForm::class, 'revision-revert' => \Drupal\Core\Entity\Form\RevisionRevertForm::class], 'route_provider' => ['revision' => \Drupal\Core\Entity\Routing\RevisionHtmlRouteProvider::class], 'translation' => 'Drupal\block_content\BlockContentTranslationHandler'], admin_permission: 'administer block content', base_table: 'block_content', revision_table: 'block_content_revision', data_table: 'block_content_field_data', revision_data_table: 'block_content_field_revision', show_revision_ui: true, links: ['canonical' => '/admin/content/block/{block_content}', 'delete-form' => '/admin/content/block/{block_content}/delete', 'edit-form' => '/admin/content/block/{block_content}', 'collection' => '/admin/content/block', 'create' => '/block', 'revision-delete-form' => '/admin/content/block/{block_content}/revision/{block_content_revision}/delete', 'revision-revert-form' => '/admin/content/block/{block_content}/revision/{block_content_revision}/revert', 'version-history' => '/admin/content/block/{block_content}/revisions'], translatable: true, entity_keys: ['id' => 'id', 'revision' => 'revision_id', 'bundle' => 'type', 'label' => 'info', 'langcode' => 'langcode', 'uuid' => 'uuid', 'published' => 'status'], revision_metadata_keys: ['revision_user' => 'revision_user', 'revision_created' => 'revision_created', 'revision_log_message' => 'revision_log'], bundle_entity_type: 'block_content_type', field_ui_base_route: 'entity.block_content_type.edit_form', render_cache: false)]
 class BlockContent extends EditorialContentEntityBase implements BlockContentInterface {
 
   use RefinableDependentAccessTrait;

--- a/core/modules/block_content/src/Entity/BlockContentType.php
+++ b/core/modules/block_content/src/Entity/BlockContentType.php
@@ -7,52 +7,8 @@ use Drupal\block_content\BlockContentTypeInterface;
 
 /**
  * Defines the block type entity.
- *
- * @ConfigEntityType(
- *   id = "block_content_type",
- *   label = @Translation("Block type"),
- *   label_collection = @Translation("Block types"),
- *   label_singular = @Translation("block type"),
- *   label_plural = @Translation("block types"),
- *   label_count = @PluralTranslation(
- *     singular = "@count block type",
- *     plural = "@count block types",
- *   ),
- *   handlers = {
- *     "access" = "Drupal\block_content\BlockTypeAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\block_content\BlockContentTypeForm",
- *       "add" = "Drupal\block_content\BlockContentTypeForm",
- *       "edit" = "Drupal\block_content\BlockContentTypeForm",
- *       "delete" = "Drupal\block_content\Form\BlockContentTypeDeleteForm"
- *     },
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\AdminHtmlRouteProvider",
- *       "permissions" = "Drupal\user\Entity\EntityPermissionsRouteProvider",
- *     },
- *     "list_builder" = "Drupal\block_content\BlockContentTypeListBuilder"
- *   },
- *   admin_permission = "administer block types",
- *   config_prefix = "type",
- *   bundle_of = "block_content",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   },
- *   links = {
- *     "delete-form" = "/admin/structure/block-content/manage/{block_content_type}/delete",
- *     "edit-form" = "/admin/structure/block-content/manage/{block_content_type}",
- *     "entity-permissions-form" = "/admin/structure/block-content/manage/{block_content_type}/permissions",
- *     "collection" = "/admin/structure/block-content",
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "revision",
- *     "description",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'block_content_type', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Block type'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Block types'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('block type'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('block types'), label_count: ['singular' => '@count block type', 'plural' => '@count block types'], handlers: ['access' => 'Drupal\block_content\BlockTypeAccessControlHandler', 'form' => ['default' => 'Drupal\block_content\BlockContentTypeForm', 'add' => 'Drupal\block_content\BlockContentTypeForm', 'edit' => 'Drupal\block_content\BlockContentTypeForm', 'delete' => 'Drupal\block_content\Form\BlockContentTypeDeleteForm'], 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\AdminHtmlRouteProvider', 'permissions' => 'Drupal\user\Entity\EntityPermissionsRouteProvider'], 'list_builder' => 'Drupal\block_content\BlockContentTypeListBuilder'], admin_permission: 'administer block types', config_prefix: 'type', bundle_of: 'block_content', entity_keys: ['id' => 'id', 'label' => 'label'], links: ['delete-form' => '/admin/structure/block-content/manage/{block_content_type}/delete', 'edit-form' => '/admin/structure/block-content/manage/{block_content_type}', 'entity-permissions-form' => '/admin/structure/block-content/manage/{block_content_type}/permissions', 'collection' => '/admin/structure/block-content'], config_export: ['id', 'label', 'revision', 'description'])]
 class BlockContentType extends ConfigEntityBundleBase implements BlockContentTypeInterface {
 
   /**

--- a/core/modules/comment/src/Entity/Comment.php
+++ b/core/modules/comment/src/Entity/Comment.php
@@ -17,57 +17,8 @@ use Drupal\user\EntityOwnerTrait;
 
 /**
  * Defines the comment entity class.
- *
- * @ContentEntityType(
- *   id = "comment",
- *   label = @Translation("Comment"),
- *   label_singular = @Translation("comment"),
- *   label_plural = @Translation("comments"),
- *   label_count = @PluralTranslation(
- *     singular = "@count comment",
- *     plural = "@count comments",
- *   ),
- *   bundle_label = @Translation("Comment type"),
- *   handlers = {
- *     "storage" = "Drupal\comment\CommentStorage",
- *     "storage_schema" = "Drupal\comment\CommentStorageSchema",
- *     "access" = "Drupal\comment\CommentAccessControlHandler",
- *     "list_builder" = "Drupal\Core\Entity\EntityListBuilder",
- *     "view_builder" = "Drupal\comment\CommentViewBuilder",
- *     "views_data" = "Drupal\comment\CommentViewsData",
- *     "form" = {
- *       "default" = "Drupal\comment\CommentForm",
- *       "delete" = "Drupal\comment\Form\DeleteForm"
- *     },
- *     "translation" = "Drupal\comment\CommentTranslationHandler"
- *   },
- *   base_table = "comment",
- *   data_table = "comment_field_data",
- *   uri_callback = "comment_uri",
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "cid",
- *     "bundle" = "comment_type",
- *     "label" = "subject",
- *     "langcode" = "langcode",
- *     "uuid" = "uuid",
- *     "published" = "status",
- *     "owner" = "uid",
- *   },
- *   links = {
- *     "canonical" = "/comment/{comment}",
- *     "delete-form" = "/comment/{comment}/delete",
- *     "delete-multiple-form" = "/admin/content/comment/delete",
- *     "edit-form" = "/comment/{comment}/edit",
- *     "create" = "/comment",
- *   },
- *   bundle_entity_type = "comment_type",
- *   field_ui_base_route  = "entity.comment_type.edit_form",
- *   constraints = {
- *     "CommentName" = {}
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'comment', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Comment'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('comment'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('comments'), label_count: ['singular' => '@count comment', 'plural' => '@count comments'], bundle_label: new Drupal\Core\StringTranslation\TranslatableMarkup('Comment type'), handlers: ['storage' => 'Drupal\comment\CommentStorage', 'storage_schema' => 'Drupal\comment\CommentStorageSchema', 'access' => 'Drupal\comment\CommentAccessControlHandler', 'list_builder' => 'Drupal\Core\Entity\EntityListBuilder', 'view_builder' => 'Drupal\comment\CommentViewBuilder', 'views_data' => 'Drupal\comment\CommentViewsData', 'form' => ['default' => 'Drupal\comment\CommentForm', 'delete' => 'Drupal\comment\Form\DeleteForm'], 'translation' => 'Drupal\comment\CommentTranslationHandler'], base_table: 'comment', data_table: 'comment_field_data', uri_callback: 'comment_uri', translatable: true, entity_keys: ['id' => 'cid', 'bundle' => 'comment_type', 'label' => 'subject', 'langcode' => 'langcode', 'uuid' => 'uuid', 'published' => 'status', 'owner' => 'uid'], links: ['canonical' => '/comment/{comment}', 'delete-form' => '/comment/{comment}/delete', 'delete-multiple-form' => '/admin/content/comment/delete', 'edit-form' => '/comment/{comment}/edit', 'create' => '/comment'], bundle_entity_type: 'comment_type', field_ui_base_route: 'entity.comment_type.edit_form', constraints: ['CommentName' => []])]
 class Comment extends ContentEntityBase implements CommentInterface {
 
   use EntityChangedTrait;

--- a/core/modules/comment/src/Entity/CommentType.php
+++ b/core/modules/comment/src/Entity/CommentType.php
@@ -7,50 +7,8 @@ use Drupal\comment\CommentTypeInterface;
 
 /**
  * Defines the comment type entity.
- *
- * @ConfigEntityType(
- *   id = "comment_type",
- *   label = @Translation("Comment type"),
- *   label_singular = @Translation("comment type"),
- *   label_plural = @Translation("comment types"),
- *   label_count = @PluralTranslation(
- *     singular = "@count comment type",
- *     plural = "@count comment types",
- *   ),
- *   handlers = {
- *     "form" = {
- *       "default" = "Drupal\comment\CommentTypeForm",
- *       "add" = "Drupal\comment\CommentTypeForm",
- *       "edit" = "Drupal\comment\CommentTypeForm",
- *       "delete" = "Drupal\comment\Form\CommentTypeDeleteForm"
- *     },
- *     "route_provider" = {
- *       "permissions" = "Drupal\user\Entity\EntityPermissionsRouteProviderWithCheck",
- *     },
- *     "list_builder" = "Drupal\comment\CommentTypeListBuilder"
- *   },
- *   admin_permission = "administer comment types",
- *   config_prefix = "type",
- *   bundle_of = "comment",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   },
- *   links = {
- *     "delete-form" = "/admin/structure/comment/manage/{comment_type}/delete",
- *     "edit-form" = "/admin/structure/comment/manage/{comment_type}",
- *     "add-form" = "/admin/structure/comment/types/add",
- *     "entity-permissions-form" = "/admin/structure/comment/manage/{comment_type}/permissions",
- *     "collection" = "/admin/structure/comment",
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "target_entity_type_id",
- *     "description",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'comment_type', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Comment type'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('comment type'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('comment types'), label_count: ['singular' => '@count comment type', 'plural' => '@count comment types'], handlers: ['form' => ['default' => 'Drupal\comment\CommentTypeForm', 'add' => 'Drupal\comment\CommentTypeForm', 'edit' => 'Drupal\comment\CommentTypeForm', 'delete' => 'Drupal\comment\Form\CommentTypeDeleteForm'], 'route_provider' => ['permissions' => 'Drupal\user\Entity\EntityPermissionsRouteProviderWithCheck'], 'list_builder' => 'Drupal\comment\CommentTypeListBuilder'], admin_permission: 'administer comment types', config_prefix: 'type', bundle_of: 'comment', entity_keys: ['id' => 'id', 'label' => 'label'], links: ['delete-form' => '/admin/structure/comment/manage/{comment_type}/delete', 'edit-form' => '/admin/structure/comment/manage/{comment_type}', 'add-form' => '/admin/structure/comment/types/add', 'entity-permissions-form' => '/admin/structure/comment/manage/{comment_type}/permissions', 'collection' => '/admin/structure/comment'], config_export: ['id', 'label', 'target_entity_type_id', 'description'])]
 class CommentType extends ConfigEntityBundleBase implements CommentTypeInterface {
 
   /**

--- a/core/modules/comment/tests/modules/comment_base_field_test/src/Entity/CommentTestBaseField.php
+++ b/core/modules/comment/tests/modules/comment_base_field_test/src/Entity/CommentTestBaseField.php
@@ -9,18 +9,8 @@ use Drupal\entity_test\Entity\EntityTest;
 
 /**
  * Defines a test entity class for comment as a base field.
- *
- * @ContentEntityType(
- *   id = "comment_test_base_field",
- *   label = @Translation("Test comment - base field"),
- *   base_table = "comment_test_base_field",
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type"
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'comment_test_base_field', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test comment - base field'), base_table: 'comment_test_base_field', entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type'])]
 class CommentTestBaseField extends EntityTest {
 
   public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {

--- a/core/modules/config/tests/config_test/src/Entity/ConfigQueryTest.php
+++ b/core/modules/config/tests/config_test/src/Entity/ConfigQueryTest.php
@@ -5,31 +5,10 @@ namespace Drupal\config_test\Entity;
 /**
  * Defines the ConfigQueryTest configuration entity used by the query test.
  *
- * @ConfigEntityType(
- *   id = "config_query_test",
- *   label = @Translation("Test configuration for query"),
- *   handlers = {
- *     "storage" = "Drupal\config_test\ConfigTestStorage",
- *     "list_builder" = "Drupal\Core\Config\Entity\ConfigEntityListBuilder",
- *     "form" = {
- *       "default" = "Drupal\config_test\ConfigTestForm"
- *     }
- *   },
- *   config_prefix = "query",
- *   config_export = {
- *     "id",
- *     "label",
- *     "array",
- *     "number",
- *   },
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   }
- * )
  *
  * @see \Drupal\system\Tests\Entity\ConfigEntityQueryTest
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'config_query_test', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test configuration for query'), handlers: ['storage' => 'Drupal\config_test\ConfigTestStorage', 'list_builder' => 'Drupal\Core\Config\Entity\ConfigEntityListBuilder', 'form' => ['default' => 'Drupal\config_test\ConfigTestForm']], config_prefix: 'query', config_export: ['id', 'label', 'array', 'number'], entity_keys: ['id' => 'id', 'label' => 'label'])]
 class ConfigQueryTest extends ConfigTest {
 
   /**

--- a/core/modules/config/tests/config_test/src/Entity/ConfigTest.php
+++ b/core/modules/config/tests/config_test/src/Entity/ConfigTest.php
@@ -9,43 +9,8 @@ use Drupal\Core\Entity\EntityStorageInterface;
 
 /**
  * Defines the ConfigTest configuration entity.
- *
- * @ConfigEntityType(
- *   id = "config_test",
- *   label = @Translation("Test configuration"),
- *   handlers = {
- *     "storage" = "Drupal\config_test\ConfigTestStorage",
- *     "list_builder" = "Drupal\config_test\ConfigTestListBuilder",
- *     "form" = {
- *       "default" = "Drupal\config_test\ConfigTestForm",
- *       "delete" = "Drupal\Core\Entity\EntityDeleteForm"
- *     },
- *     "access" = "Drupal\config_test\ConfigTestAccessControlHandler"
- *   },
- *   config_prefix = "dynamic",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label",
- *     "status" = "status"
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "weight",
- *     "style",
- *     "size",
- *     "size_value",
- *     "protected_property",
- *   },
- *   links = {
- *     "edit-form" = "/admin/structure/config_test/manage/{config_test}",
- *     "delete-form" = "/admin/structure/config_test/manage/{config_test}/delete",
- *     "enable" = "/admin/structure/config_test/manage/{config_test}/enable",
- *     "disable" = "/admin/structure/config_test/manage/{config_test}/disable",
- *     "collection" = "/admin/structure/config_test",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'config_test', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test configuration'), handlers: ['storage' => 'Drupal\config_test\ConfigTestStorage', 'list_builder' => 'Drupal\config_test\ConfigTestListBuilder', 'form' => ['default' => 'Drupal\config_test\ConfigTestForm', 'delete' => 'Drupal\Core\Entity\EntityDeleteForm'], 'access' => 'Drupal\config_test\ConfigTestAccessControlHandler'], config_prefix: 'dynamic', entity_keys: ['id' => 'id', 'label' => 'label', 'status' => 'status'], config_export: ['id', 'label', 'weight', 'style', 'size', 'size_value', 'protected_property'], links: ['edit-form' => '/admin/structure/config_test/manage/{config_test}', 'delete-form' => '/admin/structure/config_test/manage/{config_test}/delete', 'enable' => '/admin/structure/config_test/manage/{config_test}/enable', 'disable' => '/admin/structure/config_test/manage/{config_test}/disable', 'collection' => '/admin/structure/config_test'])]
 class ConfigTest extends ConfigEntityBase implements ConfigTestInterface {
 
   /**

--- a/core/modules/contact/src/Entity/ContactForm.php
+++ b/core/modules/contact/src/Entity/ContactForm.php
@@ -8,54 +8,8 @@ use Drupal\Core\Url;
 
 /**
  * Defines the contact form entity.
- *
- * @ConfigEntityType(
- *   id = "contact_form",
- *   label = @Translation("Contact form"),
- *   label_collection = @Translation("Contact forms"),
- *   label_singular = @Translation("contact form"),
- *   label_plural = @Translation("contact forms"),
- *   label_count = @PluralTranslation(
- *     singular = "@count contact form",
- *     plural = "@count contact forms",
- *   ),
- *   handlers = {
- *     "access" = "Drupal\contact\ContactFormAccessControlHandler",
- *     "list_builder" = "Drupal\contact\ContactFormListBuilder",
- *     "form" = {
- *       "add" = "Drupal\contact\ContactFormEditForm",
- *       "edit" = "Drupal\contact\ContactFormEditForm",
- *       "delete" = "Drupal\Core\Entity\EntityDeleteForm"
- *     },
- *     "route_provider" = {
- *       "permissions" = "Drupal\user\Entity\EntityPermissionsRouteProviderWithCheck",
- *     }
- *   },
- *   config_prefix = "form",
- *   admin_permission = "administer contact forms",
- *   bundle_of = "contact_message",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   },
- *   links = {
- *     "delete-form" = "/admin/structure/contact/manage/{contact_form}/delete",
- *     "edit-form" = "/admin/structure/contact/manage/{contact_form}",
- *     "entity-permissions-form" = "/admin/structure/contact/manage/{contact_form}/permissions",
- *     "collection" = "/admin/structure/contact",
- *     "canonical" = "/contact/{contact_form}",
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "recipients",
- *     "reply",
- *     "weight",
- *     "message",
- *     "redirect",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'contact_form', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Contact form'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Contact forms'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('contact form'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('contact forms'), label_count: ['singular' => '@count contact form', 'plural' => '@count contact forms'], handlers: ['access' => 'Drupal\contact\ContactFormAccessControlHandler', 'list_builder' => 'Drupal\contact\ContactFormListBuilder', 'form' => ['add' => 'Drupal\contact\ContactFormEditForm', 'edit' => 'Drupal\contact\ContactFormEditForm', 'delete' => 'Drupal\Core\Entity\EntityDeleteForm'], 'route_provider' => ['permissions' => 'Drupal\user\Entity\EntityPermissionsRouteProviderWithCheck']], config_prefix: 'form', admin_permission: 'administer contact forms', bundle_of: 'contact_message', entity_keys: ['id' => 'id', 'label' => 'label'], links: ['delete-form' => '/admin/structure/contact/manage/{contact_form}/delete', 'edit-form' => '/admin/structure/contact/manage/{contact_form}', 'entity-permissions-form' => '/admin/structure/contact/manage/{contact_form}/permissions', 'collection' => '/admin/structure/contact', 'canonical' => '/contact/{contact_form}'], config_export: ['id', 'label', 'recipients', 'reply', 'weight', 'message', 'redirect'])]
 class ContactForm extends ConfigEntityBundleBase implements ContactFormInterface {
 
   /**

--- a/core/modules/contact/src/Entity/Message.php
+++ b/core/modules/contact/src/Entity/Message.php
@@ -9,36 +9,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Defines the contact message entity.
- *
- * @ContentEntityType(
- *   id = "contact_message",
- *   label = @Translation("Contact message"),
- *   label_collection = @Translation("Contact messages"),
- *   label_singular = @Translation("contact message"),
- *   label_plural = @Translation("contact messages"),
- *   label_count = @PluralTranslation(
- *     singular = "@count contact message",
- *     plural = "@count contact messages",
- *   ),
- *   bundle_label = @Translation("Contact form"),
- *   handlers = {
- *     "access" = "Drupal\contact\ContactMessageAccessControlHandler",
- *     "storage" = "Drupal\Core\Entity\ContentEntityNullStorage",
- *     "view_builder" = "Drupal\contact\MessageViewBuilder",
- *     "form" = {
- *       "default" = "Drupal\contact\MessageForm"
- *     }
- *   },
- *   admin_permission = "administer contact forms",
- *   entity_keys = {
- *     "bundle" = "contact_form",
- *     "uuid" = "uuid",
- *     "langcode" = "langcode"
- *   },
- *   bundle_entity_type = "contact_form",
- *   field_ui_base_route = "entity.contact_form.edit_form",
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'contact_message', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Contact message'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Contact messages'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('contact message'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('contact messages'), label_count: ['singular' => '@count contact message', 'plural' => '@count contact messages'], bundle_label: new Drupal\Core\StringTranslation\TranslatableMarkup('Contact form'), handlers: ['access' => 'Drupal\contact\ContactMessageAccessControlHandler', 'storage' => 'Drupal\Core\Entity\ContentEntityNullStorage', 'view_builder' => 'Drupal\contact\MessageViewBuilder', 'form' => ['default' => 'Drupal\contact\MessageForm']], admin_permission: 'administer contact forms', entity_keys: ['bundle' => 'contact_form', 'uuid' => 'uuid', 'langcode' => 'langcode'], bundle_entity_type: 'contact_form', field_ui_base_route: 'entity.contact_form.edit_form')]
 class Message extends ContentEntityBase implements MessageInterface {
 
   /**

--- a/core/modules/content_moderation/src/Entity/ContentModerationState.php
+++ b/core/modules/content_moderation/src/Entity/ContentModerationState.php
@@ -12,41 +12,13 @@ use Drupal\user\EntityOwnerTrait;
 /**
  * Defines the Content moderation state entity.
  *
- * @ContentEntityType(
- *   id = "content_moderation_state",
- *   label = @Translation("Content moderation state"),
- *   label_singular = @Translation("content moderation state"),
- *   label_plural = @Translation("content moderation states"),
- *   label_count = @PluralTranslation(
- *     singular = "@count content moderation state",
- *     plural = "@count content moderation states"
- *   ),
- *   handlers = {
- *     "storage_schema" = "Drupal\content_moderation\ContentModerationStateStorageSchema",
- *     "views_data" = "\Drupal\views\EntityViewsData",
- *     "access" = "Drupal\content_moderation\ContentModerationStateAccessControlHandler",
- *   },
- *   base_table = "content_moderation_state",
- *   revision_table = "content_moderation_state_revision",
- *   data_table = "content_moderation_state_field_data",
- *   revision_data_table = "content_moderation_state_field_revision",
- *   translatable = TRUE,
- *   internal = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "revision" = "revision_id",
- *     "uuid" = "uuid",
- *     "uid" = "uid",
- *     "owner" = "uid",
- *     "langcode" = "langcode",
- *   }
- * )
  *
  * @internal
  *   This entity is marked internal because it should not be used directly to
  *   alter the moderation state of an entity. Instead, the computed
  *   moderation_state field should be set on the entity directly.
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'content_moderation_state', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Content moderation state'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('content moderation state'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('content moderation states'), label_count: ['singular' => '@count content moderation state', 'plural' => '@count content moderation states'], handlers: ['storage_schema' => 'Drupal\content_moderation\ContentModerationStateStorageSchema', 'views_data' => '\Drupal\views\EntityViewsData', 'access' => 'Drupal\content_moderation\ContentModerationStateAccessControlHandler'], base_table: 'content_moderation_state', revision_table: 'content_moderation_state_revision', data_table: 'content_moderation_state_field_data', revision_data_table: 'content_moderation_state_field_revision', translatable: true, internal: true, entity_keys: ['id' => 'id', 'revision' => 'revision_id', 'uuid' => 'uuid', 'uid' => 'uid', 'owner' => 'uid', 'langcode' => 'langcode'])]
 class ContentModerationState extends ContentEntityBase implements ContentModerationStateInterface {
 
   use EntityOwnerTrait;

--- a/core/modules/content_translation/tests/modules/content_translation_test/src/Entity/EntityTestTranslatableNoUISkip.php
+++ b/core/modules/content_translation/tests/modules/content_translation_test/src/Entity/EntityTestTranslatableNoUISkip.php
@@ -6,34 +6,8 @@ use Drupal\entity_test\Entity\EntityTest;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_translatable_no_skip",
- *   label = @Translation("Test entity - Translatable check UI"),
- *   handlers = {
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm",
- *      },
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *   },
- *   base_table = "entity_test_mul",
- *   data_table = "entity_test_mul_property_data",
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- *   translatable = TRUE,
- *   admin_permission = "administer entity_test content",
- *   links = {
- *     "edit-form" = "/entity_test_translatable_no_skip/{entity_test_translatable_no_skip}/edit",
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_translatable_no_skip', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - Translatable check UI'), handlers: ['form' => ['default' => 'Drupal\entity_test\EntityTestForm'], 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider']], base_table: 'entity_test_mul', data_table: 'entity_test_mul_property_data', entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'], translatable: true, admin_permission: 'administer entity_test content', links: ['edit-form' => '/entity_test_translatable_no_skip/{entity_test_translatable_no_skip}/edit'])]
 class EntityTestTranslatableNoUISkip extends EntityTest {
 
 }

--- a/core/modules/content_translation/tests/modules/content_translation_test/src/Entity/EntityTestTranslatableUISkip.php
+++ b/core/modules/content_translation/tests/modules/content_translation_test/src/Entity/EntityTestTranslatableUISkip.php
@@ -6,23 +6,8 @@ use Drupal\entity_test\Entity\EntityTest;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_translatable_UI_skip",
- *   label = @Translation("Test entity - Translatable skip UI check"),
- *   base_table = "entity_test_mul",
- *   data_table = "entity_test_mul_property_data",
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- *   translatable = TRUE,
- *   content_translation_ui_skip = TRUE,
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_translatable_UI_skip', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - Translatable skip UI check'), base_table: 'entity_test_mul', data_table: 'entity_test_mul_property_data', entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'], translatable: true, content_translation_ui_skip: true)]
 class EntityTestTranslatableUISkip extends EntityTest {
 
 }

--- a/core/modules/editor/src/Entity/Editor.php
+++ b/core/modules/editor/src/Entity/Editor.php
@@ -8,36 +8,8 @@ use Drupal\editor\EditorInterface;
 
 /**
  * Defines the configured text editor entity.
- *
- * @ConfigEntityType(
- *   id = "editor",
- *   label = @Translation("Text editor"),
- *   label_collection = @Translation("Text editors"),
- *   label_singular = @Translation("text editor"),
- *   label_plural = @Translation("text editors"),
- *   label_count = @PluralTranslation(
- *     singular = "@count text editor",
- *     plural = "@count text editors",
- *   ),
- *   handlers = {
- *     "access" = "Drupal\editor\EditorAccessControlHandler",
- *   },
- *   entity_keys = {
- *     "id" = "format"
- *   },
- *   config_export = {
- *     "format",
- *     "editor",
- *     "settings",
- *     "image_upload",
- *   },
- *   constraints = {
- *     "RequiredConfigDependencies" = {
- *       "filter_format"
- *     }
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'editor', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Text editor'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Text editors'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('text editor'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('text editors'), label_count: ['singular' => '@count text editor', 'plural' => '@count text editors'], handlers: ['access' => 'Drupal\editor\EditorAccessControlHandler'], entity_keys: ['id' => 'format'], config_export: ['format', 'editor', 'settings', 'image_upload'], constraints: ['RequiredConfigDependencies' => ['filter_format']])]
 class Editor extends ConfigEntityBase implements EditorInterface {
 
   /**

--- a/core/modules/field/src/Entity/FieldConfig.php
+++ b/core/modules/field/src/Entity/FieldConfig.php
@@ -11,47 +11,8 @@ use Drupal\field\FieldConfigInterface;
 
 /**
  * Defines the Field entity.
- *
- * @ConfigEntityType(
- *   id = "field_config",
- *   label = @Translation("Field"),
- *   label_collection = @Translation("Fields"),
- *   label_singular = @Translation("field"),
- *   label_plural = @Translation("fields"),
- *   label_count = @PluralTranslation(
- *     singular = "@count field",
- *     plural = "@count fields",
- *   ),
- *   handlers = {
- *     "access" = "Drupal\field\FieldConfigAccessControlHandler",
- *     "storage" = "Drupal\field\FieldConfigStorage"
- *   },
- *   config_prefix = "field",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   },
- *   config_export = {
- *     "id",
- *     "field_name",
- *     "entity_type",
- *     "bundle",
- *     "label",
- *     "description",
- *     "required",
- *     "translatable",
- *     "default_value",
- *     "default_value_callback",
- *     "settings",
- *     "field_type",
- *   },
- *   constraints = {
- *     "RequiredConfigDependencies" = {
- *       "field_storage_config"
- *     }
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'field_config', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Field'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Fields'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('field'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('fields'), label_count: ['singular' => '@count field', 'plural' => '@count fields'], handlers: ['access' => 'Drupal\field\FieldConfigAccessControlHandler', 'storage' => 'Drupal\field\FieldConfigStorage'], config_prefix: 'field', entity_keys: ['id' => 'id', 'label' => 'label'], config_export: ['id', 'field_name', 'entity_type', 'bundle', 'label', 'description', 'required', 'translatable', 'default_value', 'default_value_callback', 'settings', 'field_type'], constraints: ['RequiredConfigDependencies' => ['field_storage_config']])]
 class FieldConfig extends FieldConfigBase implements FieldConfigInterface {
 
   /**

--- a/core/modules/field/src/Entity/FieldStorageConfig.php
+++ b/core/modules/field/src/Entity/FieldStorageConfig.php
@@ -13,42 +13,8 @@ use Drupal\field\FieldStorageConfigInterface;
 
 /**
  * Defines the Field storage configuration entity.
- *
- * @ConfigEntityType(
- *   id = "field_storage_config",
- *   label = @Translation("Field storage"),
- *   label_collection = @Translation("Field storages"),
- *   label_singular = @Translation("field storage"),
- *   label_plural = @Translation("field storages"),
- *   label_count = @PluralTranslation(
- *     singular = "@count field storage",
- *     plural = "@count field storages",
- *   ),
- *   handlers = {
- *     "access" = "Drupal\field\FieldStorageConfigAccessControlHandler",
- *     "storage" = "Drupal\field\FieldStorageConfigStorage"
- *   },
- *   config_prefix = "storage",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "id"
- *   },
- *   config_export = {
- *     "id",
- *     "field_name",
- *     "entity_type",
- *     "type",
- *     "settings",
- *     "module",
- *     "locked",
- *     "cardinality",
- *     "translatable",
- *     "indexes",
- *     "persist_with_no_fields",
- *     "custom_storage",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'field_storage_config', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Field storage'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Field storages'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('field storage'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('field storages'), label_count: ['singular' => '@count field storage', 'plural' => '@count field storages'], handlers: ['access' => 'Drupal\field\FieldStorageConfigAccessControlHandler', 'storage' => 'Drupal\field\FieldStorageConfigStorage'], config_prefix: 'storage', entity_keys: ['id' => 'id', 'label' => 'id'], config_export: ['id', 'field_name', 'entity_type', 'type', 'settings', 'module', 'locked', 'cardinality', 'translatable', 'indexes', 'persist_with_no_fields', 'custom_storage'])]
 class FieldStorageConfig extends ConfigEntityBase implements FieldStorageConfigInterface {
 
   /**

--- a/core/modules/file/src/Entity/File.php
+++ b/core/modules/file/src/Entity/File.php
@@ -16,43 +16,8 @@ use Drupal\user\EntityOwnerTrait;
  * Defines the file entity class.
  *
  * @ingroup file
- *
- * @ContentEntityType(
- *   id = "file",
- *   label = @Translation("File"),
- *   label_collection = @Translation("Files"),
- *   label_singular = @Translation("file"),
- *   label_plural = @Translation("files"),
- *   label_count = @PluralTranslation(
- *     singular = "@count file",
- *     plural = "@count files",
- *   ),
- *   handlers = {
- *     "storage" = "Drupal\file\FileStorage",
- *     "storage_schema" = "Drupal\file\FileStorageSchema",
- *     "access" = "Drupal\file\FileAccessControlHandler",
- *     "views_data" = "Drupal\file\FileViewsData",
- *     "list_builder" = "Drupal\Core\Entity\EntityListBuilder",
- *     "form" = {
- *       "delete" = "Drupal\Core\Entity\ContentEntityDeleteForm",
- *     },
- *     "route_provider" = {
- *       "html" = "Drupal\file\Entity\FileRouteProvider",
- *     },
- *   },
- *   base_table = "file_managed",
- *   entity_keys = {
- *     "id" = "fid",
- *     "label" = "filename",
- *     "langcode" = "langcode",
- *     "uuid" = "uuid",
- *     "owner" = "uid",
- *   },
- *   links = {
- *     "delete-form" = "/file/{file}/delete",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'file', label: new Drupal\Core\StringTranslation\TranslatableMarkup('File'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Files'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('file'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('files'), label_count: ['singular' => '@count file', 'plural' => '@count files'], handlers: ['storage' => 'Drupal\file\FileStorage', 'storage_schema' => 'Drupal\file\FileStorageSchema', 'access' => 'Drupal\file\FileAccessControlHandler', 'views_data' => 'Drupal\file\FileViewsData', 'list_builder' => 'Drupal\Core\Entity\EntityListBuilder', 'form' => ['delete' => 'Drupal\Core\Entity\ContentEntityDeleteForm'], 'route_provider' => ['html' => 'Drupal\file\Entity\FileRouteProvider']], base_table: 'file_managed', entity_keys: ['id' => 'fid', 'label' => 'filename', 'langcode' => 'langcode', 'uuid' => 'uuid', 'owner' => 'uid'], links: ['delete-form' => '/file/{file}/delete'])]
 class File extends ContentEntityBase implements FileInterface {
 
   use EntityChangedTrait;

--- a/core/modules/filter/src/Entity/FilterFormat.php
+++ b/core/modules/filter/src/Entity/FilterFormat.php
@@ -12,47 +12,8 @@ use Drupal\filter\Plugin\FilterInterface;
 
 /**
  * Represents a text format.
- *
- * @ConfigEntityType(
- *   id = "filter_format",
- *   label = @Translation("Text format"),
- *   label_collection = @Translation("Text formats"),
- *   label_singular = @Translation("text format"),
- *   label_plural = @Translation("text formats"),
- *   label_count = @PluralTranslation(
- *     singular = "@count text format",
- *     plural = "@count text formats",
- *   ),
- *   handlers = {
- *     "form" = {
- *       "add" = "Drupal\filter\FilterFormatAddForm",
- *       "edit" = "Drupal\filter\FilterFormatEditForm",
- *       "disable" = "Drupal\filter\Form\FilterDisableForm"
- *     },
- *     "list_builder" = "Drupal\filter\FilterFormatListBuilder",
- *     "access" = "Drupal\filter\FilterFormatAccessControlHandler",
- *   },
- *   config_prefix = "format",
- *   admin_permission = "administer filters",
- *   entity_keys = {
- *     "id" = "format",
- *     "label" = "name",
- *     "weight" = "weight",
- *     "status" = "status"
- *   },
- *   links = {
- *     "edit-form" = "/admin/config/content/formats/manage/{filter_format}",
- *     "disable" = "/admin/config/content/formats/manage/{filter_format}/disable"
- *   },
- *   config_export = {
- *     "name",
- *     "format",
- *     "weight",
- *     "roles",
- *     "filters",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'filter_format', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Text format'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Text formats'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('text format'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('text formats'), label_count: ['singular' => '@count text format', 'plural' => '@count text formats'], handlers: ['form' => ['add' => 'Drupal\filter\FilterFormatAddForm', 'edit' => 'Drupal\filter\FilterFormatEditForm', 'disable' => 'Drupal\filter\Form\FilterDisableForm'], 'list_builder' => 'Drupal\filter\FilterFormatListBuilder', 'access' => 'Drupal\filter\FilterFormatAccessControlHandler'], config_prefix: 'format', admin_permission: 'administer filters', entity_keys: ['id' => 'format', 'label' => 'name', 'weight' => 'weight', 'status' => 'status'], links: ['edit-form' => '/admin/config/content/formats/manage/{filter_format}', 'disable' => '/admin/config/content/formats/manage/{filter_format}/disable'], config_export: ['name', 'format', 'weight', 'roles', 'filters'])]
 class FilterFormat extends ConfigEntityBase implements FilterFormatInterface, EntityWithPluginCollectionInterface {
 
   /**

--- a/core/modules/image/src/Entity/ImageStyle.php
+++ b/core/modules/image/src/Entity/ImageStyle.php
@@ -24,46 +24,8 @@ use Drupal\Core\Entity\Entity\EntityViewDisplay;
 
 /**
  * Defines an image style configuration entity.
- *
- * @ConfigEntityType(
- *   id = "image_style",
- *   label = @Translation("Image style"),
- *   label_collection = @Translation("Image styles"),
- *   label_singular = @Translation("image style"),
- *   label_plural = @Translation("image styles"),
- *   label_count = @PluralTranslation(
- *     singular = "@count image style",
- *     plural = "@count image styles",
- *   ),
- *   handlers = {
- *     "form" = {
- *       "add" = "Drupal\image\Form\ImageStyleAddForm",
- *       "edit" = "Drupal\image\Form\ImageStyleEditForm",
- *       "delete" = "Drupal\image\Form\ImageStyleDeleteForm",
- *       "flush" = "Drupal\image\Form\ImageStyleFlushForm"
- *     },
- *     "list_builder" = "Drupal\image\ImageStyleListBuilder",
- *     "storage" = "Drupal\image\ImageStyleStorage",
- *   },
- *   admin_permission = "administer image styles",
- *   config_prefix = "style",
- *   entity_keys = {
- *     "id" = "name",
- *     "label" = "label"
- *   },
- *   links = {
- *     "flush-form" = "/admin/config/media/image-styles/manage/{image_style}/flush",
- *     "edit-form" = "/admin/config/media/image-styles/manage/{image_style}",
- *     "delete-form" = "/admin/config/media/image-styles/manage/{image_style}/delete",
- *     "collection" = "/admin/config/media/image-styles",
- *   },
- *   config_export = {
- *     "name",
- *     "label",
- *     "effects",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'image_style', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Image style'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Image styles'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('image style'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('image styles'), label_count: ['singular' => '@count image style', 'plural' => '@count image styles'], handlers: ['form' => ['add' => 'Drupal\image\Form\ImageStyleAddForm', 'edit' => 'Drupal\image\Form\ImageStyleEditForm', 'delete' => 'Drupal\image\Form\ImageStyleDeleteForm', 'flush' => 'Drupal\image\Form\ImageStyleFlushForm'], 'list_builder' => 'Drupal\image\ImageStyleListBuilder', 'storage' => 'Drupal\image\ImageStyleStorage'], admin_permission: 'administer image styles', config_prefix: 'style', entity_keys: ['id' => 'name', 'label' => 'label'], links: ['flush-form' => '/admin/config/media/image-styles/manage/{image_style}/flush', 'edit-form' => '/admin/config/media/image-styles/manage/{image_style}', 'delete-form' => '/admin/config/media/image-styles/manage/{image_style}/delete', 'collection' => '/admin/config/media/image-styles'], config_export: ['name', 'label', 'effects'])]
 class ImageStyle extends ConfigEntityBase implements ImageStyleInterface, EntityWithPluginCollectionInterface {
 
   /**

--- a/core/modules/language/src/Entity/ConfigurableLanguage.php
+++ b/core/modules/language/src/Entity/ConfigurableLanguage.php
@@ -12,47 +12,8 @@ use Drupal\language\ConfigurableLanguageInterface;
 
 /**
  * Defines the ConfigurableLanguage entity.
- *
- * @ConfigEntityType(
- *   id = "configurable_language",
- *   label = @Translation("Language"),
- *   label_collection = @Translation("Languages"),
- *   label_singular = @Translation("language"),
- *   label_plural = @Translation("languages"),
- *   label_count = @PluralTranslation(
- *     singular = "@count language",
- *     plural = "@count languages",
- *   ),
- *   handlers = {
- *     "list_builder" = "Drupal\language\LanguageListBuilder",
- *     "access" = "Drupal\language\LanguageAccessControlHandler",
- *     "form" = {
- *       "add" = "Drupal\language\Form\LanguageAddForm",
- *       "edit" = "Drupal\language\Form\LanguageEditForm",
- *       "delete" = "Drupal\language\Form\LanguageDeleteForm"
- *     }
- *   },
- *   admin_permission = "administer languages",
- *   config_prefix = "entity",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label",
- *     "weight" = "weight"
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "direction",
- *     "weight",
- *     "locked"
- *   },
- *   links = {
- *     "delete-form" = "/admin/config/regional/language/delete/{configurable_language}",
- *     "edit-form" = "/admin/config/regional/language/edit/{configurable_language}",
- *     "collection" = "/admin/config/regional/language",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'configurable_language', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Language'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Languages'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('language'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('languages'), label_count: ['singular' => '@count language', 'plural' => '@count languages'], handlers: ['list_builder' => 'Drupal\language\LanguageListBuilder', 'access' => 'Drupal\language\LanguageAccessControlHandler', 'form' => ['add' => 'Drupal\language\Form\LanguageAddForm', 'edit' => 'Drupal\language\Form\LanguageEditForm', 'delete' => 'Drupal\language\Form\LanguageDeleteForm']], admin_permission: 'administer languages', config_prefix: 'entity', entity_keys: ['id' => 'id', 'label' => 'label', 'weight' => 'weight'], config_export: ['id', 'label', 'direction', 'weight', 'locked'], links: ['delete-form' => '/admin/config/regional/language/delete/{configurable_language}', 'edit-form' => '/admin/config/regional/language/edit/{configurable_language}', 'collection' => '/admin/config/regional/language'])]
 class ConfigurableLanguage extends ConfigEntityBase implements ConfigurableLanguageInterface {
 
   /**

--- a/core/modules/language/src/Entity/ContentLanguageSettings.php
+++ b/core/modules/language/src/Entity/ContentLanguageSettings.php
@@ -10,32 +10,8 @@ use Drupal\language\ContentLanguageSettingsInterface;
 
 /**
  * Defines the ContentLanguageSettings entity.
- *
- * @ConfigEntityType(
- *   id = "language_content_settings",
- *   label = @Translation("Content language settings"),
- *   label_collection = @Translation("Content language settings"),
- *   label_singular = @Translation("content language setting"),
- *   label_plural = @Translation("content languages settings"),
- *   label_count = @PluralTranslation(
- *     singular = "@count content language setting",
- *     plural = "@count content languages settings",
- *   ),
- *   admin_permission = "administer languages",
- *   config_prefix = "content_settings",
- *   entity_keys = {
- *     "id" = "id"
- *   },
- *   config_export = {
- *     "id",
- *     "target_entity_type_id",
- *     "target_bundle",
- *     "default_langcode",
- *     "language_alterable",
- *   },
- *   list_cache_tags = { "rendered" }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'language_content_settings', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Content language settings'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Content language settings'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('content language setting'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('content languages settings'), label_count: ['singular' => '@count content language setting', 'plural' => '@count content languages settings'], admin_permission: 'administer languages', config_prefix: 'content_settings', entity_keys: ['id' => 'id'], config_export: ['id', 'target_entity_type_id', 'target_bundle', 'default_langcode', 'language_alterable'], list_cache_tags: ['rendered'])]
 class ContentLanguageSettings extends ConfigEntityBase implements ContentLanguageSettingsInterface {
 
   /**

--- a/core/modules/language/tests/language_test/src/Entity/NoLanguageEntityTest.php
+++ b/core/modules/language/tests/language_test/src/Entity/NoLanguageEntityTest.php
@@ -8,21 +8,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "no_language_entity_test",
- *   label = @Translation("Test entity without language support"),
- *   handlers = {
- *     "views_data" = "Drupal\entity_test\EntityTestViewsData"
- *   },
- *   base_table = "no_language_entity_test",
- *   persistent_cache = FALSE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'no_language_entity_test', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity without language support'), handlers: ['views_data' => 'Drupal\entity_test\EntityTestViewsData'], base_table: 'no_language_entity_test', persistent_cache: false, entity_keys: ['id' => 'id', 'uuid' => 'uuid'])]
 class NoLanguageEntityTest extends ContentEntityBase {
 
   /**

--- a/core/modules/media/src/Entity/Media.php
+++ b/core/modules/media/src/Entity/Media.php
@@ -17,72 +17,8 @@ use Drupal\user\EntityOwnerTrait;
  *
  * @todo Remove default/fallback entity form operation when #2006348 is done.
  * @see https://www.drupal.org/node/2006348.
- *
- * @ContentEntityType(
- *   id = "media",
- *   label = @Translation("Media"),
- *   label_singular = @Translation("media item"),
- *   label_plural = @Translation("media items"),
- *   label_count = @PluralTranslation(
- *     singular = "@count media item",
- *     plural = "@count media items"
- *   ),
- *   bundle_label = @Translation("Media type"),
- *   handlers = {
- *     "storage" = "Drupal\media\MediaStorage",
- *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
- *     "list_builder" = "Drupal\media\MediaListBuilder",
- *     "access" = "Drupal\media\MediaAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\media\MediaForm",
- *       "add" = "Drupal\media\MediaForm",
- *       "edit" = "Drupal\media\MediaForm",
- *       "delete" = "Drupal\Core\Entity\ContentEntityDeleteForm",
- *       "delete-multiple-confirm" = "Drupal\Core\Entity\Form\DeleteMultipleForm",
- *     },
- *     "views_data" = "Drupal\media\MediaViewsData",
- *     "route_provider" = {
- *       "html" = "Drupal\media\Routing\MediaRouteProvider",
- *     }
- *   },
- *   base_table = "media",
- *   data_table = "media_field_data",
- *   revision_table = "media_revision",
- *   revision_data_table = "media_field_revision",
- *   translatable = TRUE,
- *   show_revision_ui = TRUE,
- *   entity_keys = {
- *     "id" = "mid",
- *     "revision" = "vid",
- *     "bundle" = "bundle",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *     "uuid" = "uuid",
- *     "published" = "status",
- *     "owner" = "uid",
- *   },
- *   revision_metadata_keys = {
- *     "revision_user" = "revision_user",
- *     "revision_created" = "revision_created",
- *     "revision_log_message" = "revision_log_message",
- *   },
- *   bundle_entity_type = "media_type",
- *   permission_granularity = "bundle",
- *   admin_permission = "administer media",
- *   field_ui_base_route = "entity.media_type.edit_form",
- *   common_reference_target = TRUE,
- *   links = {
- *     "add-page" = "/media/add",
- *     "add-form" = "/media/add/{media_type}",
- *     "canonical" = "/media/{media}/edit",
- *     "collection" = "/admin/content/media",
- *     "delete-form" = "/media/{media}/delete",
- *     "delete-multiple-form" = "/media/delete",
- *     "edit-form" = "/media/{media}/edit",
- *     "revision" = "/media/{media}/revisions/{media_revision}/view",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'media', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Media'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('media item'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('media items'), label_count: ['singular' => '@count media item', 'plural' => '@count media items'], bundle_label: new Drupal\Core\StringTranslation\TranslatableMarkup('Media type'), handlers: ['storage' => 'Drupal\media\MediaStorage', 'view_builder' => 'Drupal\Core\Entity\EntityViewBuilder', 'list_builder' => 'Drupal\media\MediaListBuilder', 'access' => 'Drupal\media\MediaAccessControlHandler', 'form' => ['default' => 'Drupal\media\MediaForm', 'add' => 'Drupal\media\MediaForm', 'edit' => 'Drupal\media\MediaForm', 'delete' => 'Drupal\Core\Entity\ContentEntityDeleteForm', 'delete-multiple-confirm' => 'Drupal\Core\Entity\Form\DeleteMultipleForm'], 'views_data' => 'Drupal\media\MediaViewsData', 'route_provider' => ['html' => 'Drupal\media\Routing\MediaRouteProvider']], base_table: 'media', data_table: 'media_field_data', revision_table: 'media_revision', revision_data_table: 'media_field_revision', translatable: true, show_revision_ui: true, entity_keys: ['id' => 'mid', 'revision' => 'vid', 'bundle' => 'bundle', 'label' => 'name', 'langcode' => 'langcode', 'uuid' => 'uuid', 'published' => 'status', 'owner' => 'uid'], revision_metadata_keys: ['revision_user' => 'revision_user', 'revision_created' => 'revision_created', 'revision_log_message' => 'revision_log_message'], bundle_entity_type: 'media_type', permission_granularity: 'bundle', admin_permission: 'administer media', field_ui_base_route: 'entity.media_type.edit_form', common_reference_target: true, links: ['add-page' => '/media/add', 'add-form' => '/media/add/{media_type}', 'canonical' => '/media/{media}/edit', 'collection' => '/admin/content/media', 'delete-form' => '/media/{media}/delete', 'delete-multiple-form' => '/media/delete', 'edit-form' => '/media/{media}/edit', 'revision' => '/media/{media}/revisions/{media_revision}/view'])]
 class Media extends EditorialContentEntityBase implements MediaInterface {
 
   use EntityOwnerTrait;

--- a/core/modules/media/src/Entity/MediaType.php
+++ b/core/modules/media/src/Entity/MediaType.php
@@ -9,58 +9,8 @@ use Drupal\media\MediaTypeInterface;
 
 /**
  * Defines the Media type configuration entity.
- *
- * @ConfigEntityType(
- *   id = "media_type",
- *   label = @Translation("Media type"),
- *   label_collection = @Translation("Media types"),
- *   label_singular = @Translation("media type"),
- *   label_plural = @Translation("media types"),
- *   label_count = @PluralTranslation(
- *     singular = "@count media type",
- *     plural = "@count media types"
- *   ),
- *   handlers = {
- *     "access" = "Drupal\media\MediaTypeAccessControlHandler",
- *     "form" = {
- *       "add" = "Drupal\media\MediaTypeForm",
- *       "edit" = "Drupal\media\MediaTypeForm",
- *       "delete" = "Drupal\media\Form\MediaTypeDeleteConfirmForm"
- *     },
- *     "list_builder" = "Drupal\media\MediaTypeListBuilder",
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *       "permissions" = "Drupal\user\Entity\EntityPermissionsRouteProvider",
- *     }
- *   },
- *   admin_permission = "administer media types",
- *   config_prefix = "type",
- *   bundle_of = "media",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label",
- *     "status" = "status",
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "description",
- *     "source",
- *     "queue_thumbnail_downloads",
- *     "new_revision",
- *     "source_configuration",
- *     "field_map",
- *     "status",
- *   },
- *   links = {
- *     "add-form" = "/admin/structure/media/add",
- *     "edit-form" = "/admin/structure/media/manage/{media_type}",
- *     "delete-form" = "/admin/structure/media/manage/{media_type}/delete",
- *     "entity-permissions-form" = "/admin/structure/media/manage/{media_type}/permissions",
- *     "collection" = "/admin/structure/media",
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'media_type', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Media type'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Media types'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('media type'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('media types'), label_count: ['singular' => '@count media type', 'plural' => '@count media types'], handlers: ['access' => 'Drupal\media\MediaTypeAccessControlHandler', 'form' => ['add' => 'Drupal\media\MediaTypeForm', 'edit' => 'Drupal\media\MediaTypeForm', 'delete' => 'Drupal\media\Form\MediaTypeDeleteConfirmForm'], 'list_builder' => 'Drupal\media\MediaTypeListBuilder', 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider', 'permissions' => 'Drupal\user\Entity\EntityPermissionsRouteProvider']], admin_permission: 'administer media types', config_prefix: 'type', bundle_of: 'media', entity_keys: ['id' => 'id', 'label' => 'label', 'status' => 'status'], config_export: ['id', 'label', 'description', 'source', 'queue_thumbnail_downloads', 'new_revision', 'source_configuration', 'field_map', 'status'], links: ['add-form' => '/admin/structure/media/add', 'edit-form' => '/admin/structure/media/manage/{media_type}', 'delete-form' => '/admin/structure/media/manage/{media_type}/delete', 'entity-permissions-form' => '/admin/structure/media/manage/{media_type}/permissions', 'collection' => '/admin/structure/media'])]
 class MediaType extends ConfigEntityBundleBase implements MediaTypeInterface, EntityWithPluginCollectionInterface {
 
   /**

--- a/core/modules/menu_link_content/src/Entity/MenuLinkContent.php
+++ b/core/modules/menu_link_content/src/Entity/MenuLinkContent.php
@@ -14,57 +14,8 @@ use Drupal\menu_link_content\MenuLinkContentInterface;
  *
  * @property \Drupal\Core\Field\FieldItemList $link
  * @property \Drupal\Core\Field\FieldItemList $rediscover
- *
- * @ContentEntityType(
- *   id = "menu_link_content",
- *   label = @Translation("Custom menu link"),
- *   label_collection = @Translation("Custom menu links"),
- *   label_singular = @Translation("custom menu link"),
- *   label_plural = @Translation("custom menu links"),
- *   label_count = @PluralTranslation(
- *     singular = "@count custom menu link",
- *     plural = "@count custom menu links",
- *   ),
- *   handlers = {
- *     "storage" = "\Drupal\menu_link_content\MenuLinkContentStorage",
- *     "storage_schema" = "Drupal\menu_link_content\MenuLinkContentStorageSchema",
- *     "access" = "Drupal\menu_link_content\MenuLinkContentAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\menu_link_content\Form\MenuLinkContentForm",
- *       "delete" = "Drupal\menu_link_content\Form\MenuLinkContentDeleteForm"
- *     },
- *     "list_builder" = "Drupal\menu_link_content\MenuLinkListBuilder"
- *   },
- *   admin_permission = "administer menu",
- *   base_table = "menu_link_content",
- *   data_table = "menu_link_content_data",
- *   revision_table = "menu_link_content_revision",
- *   revision_data_table = "menu_link_content_field_revision",
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "revision" = "revision_id",
- *     "label" = "title",
- *     "langcode" = "langcode",
- *     "uuid" = "uuid",
- *     "bundle" = "bundle",
- *     "published" = "enabled",
- *   },
- *   revision_metadata_keys = {
- *     "revision_user" = "revision_user",
- *     "revision_created" = "revision_created",
- *     "revision_log_message" = "revision_log_message",
- *   },
- *   links = {
- *     "canonical" = "/admin/structure/menu/item/{menu_link_content}/edit",
- *     "edit-form" = "/admin/structure/menu/item/{menu_link_content}/edit",
- *     "delete-form" = "/admin/structure/menu/item/{menu_link_content}/delete",
- *   },
- *   constraints = {
- *     "MenuTreeHierarchy" = {}
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'menu_link_content', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Custom menu link'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Custom menu links'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('custom menu link'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('custom menu links'), label_count: ['singular' => '@count custom menu link', 'plural' => '@count custom menu links'], handlers: ['storage' => '\Drupal\menu_link_content\MenuLinkContentStorage', 'storage_schema' => 'Drupal\menu_link_content\MenuLinkContentStorageSchema', 'access' => 'Drupal\menu_link_content\MenuLinkContentAccessControlHandler', 'form' => ['default' => 'Drupal\menu_link_content\Form\MenuLinkContentForm', 'delete' => 'Drupal\menu_link_content\Form\MenuLinkContentDeleteForm'], 'list_builder' => 'Drupal\menu_link_content\MenuLinkListBuilder'], admin_permission: 'administer menu', base_table: 'menu_link_content', data_table: 'menu_link_content_data', revision_table: 'menu_link_content_revision', revision_data_table: 'menu_link_content_field_revision', translatable: true, entity_keys: ['id' => 'id', 'revision' => 'revision_id', 'label' => 'title', 'langcode' => 'langcode', 'uuid' => 'uuid', 'bundle' => 'bundle', 'published' => 'enabled'], revision_metadata_keys: ['revision_user' => 'revision_user', 'revision_created' => 'revision_created', 'revision_log_message' => 'revision_log_message'], links: ['canonical' => '/admin/structure/menu/item/{menu_link_content}/edit', 'edit-form' => '/admin/structure/menu/item/{menu_link_content}/edit', 'delete-form' => '/admin/structure/menu/item/{menu_link_content}/delete'], constraints: ['MenuTreeHierarchy' => []])]
 class MenuLinkContent extends EditorialContentEntityBase implements MenuLinkContentInterface {
 
   /**

--- a/core/modules/migrate/tests/modules/migrate_entity_test/src/Entity/StringIdEntityTest.php
+++ b/core/modules/migrate/tests/modules/migrate_entity_test/src/Entity/StringIdEntityTest.php
@@ -8,16 +8,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Defines a content entity type that has a string ID.
- *
- * @ContentEntityType(
- *   id = "migrate_string_id_entity_test",
- *   label = @Translation("String id entity test"),
- *   base_table = "migrate_entity_test_string_id",
- *   entity_keys = {
- *     "id" = "id",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'migrate_string_id_entity_test', label: new Drupal\Core\StringTranslation\TranslatableMarkup('String id entity test'), base_table: 'migrate_entity_test_string_id', entity_keys: ['id' => 'id'])]
 class StringIdEntityTest extends ContentEntityBase {
 
   /**

--- a/core/modules/node/src/Entity/Node.php
+++ b/core/modules/node/src/Entity/Node.php
@@ -12,75 +12,8 @@ use Drupal\user\EntityOwnerTrait;
 
 /**
  * Defines the node entity class.
- *
- * @ContentEntityType(
- *   id = "node",
- *   label = @Translation("Content"),
- *   label_collection = @Translation("Content"),
- *   label_singular = @Translation("content item"),
- *   label_plural = @Translation("content items"),
- *   label_count = @PluralTranslation(
- *     singular = "@count content item",
- *     plural = "@count content items"
- *   ),
- *   bundle_label = @Translation("Content type"),
- *   handlers = {
- *     "storage" = "Drupal\node\NodeStorage",
- *     "storage_schema" = "Drupal\node\NodeStorageSchema",
- *     "view_builder" = "Drupal\node\NodeViewBuilder",
- *     "access" = "Drupal\node\NodeAccessControlHandler",
- *     "views_data" = "Drupal\node\NodeViewsData",
- *     "form" = {
- *       "default" = "Drupal\node\NodeForm",
- *       "delete" = "Drupal\node\Form\NodeDeleteForm",
- *       "edit" = "Drupal\node\NodeForm",
- *       "delete-multiple-confirm" = "Drupal\node\Form\DeleteMultiple"
- *     },
- *     "route_provider" = {
- *       "html" = "Drupal\node\Entity\NodeRouteProvider",
- *     },
- *     "list_builder" = "Drupal\node\NodeListBuilder",
- *     "translation" = "Drupal\node\NodeTranslationHandler"
- *   },
- *   base_table = "node",
- *   data_table = "node_field_data",
- *   revision_table = "node_revision",
- *   revision_data_table = "node_field_revision",
- *   show_revision_ui = TRUE,
- *   translatable = TRUE,
- *   list_cache_contexts = { "user.node_grants:view" },
- *   entity_keys = {
- *     "id" = "nid",
- *     "revision" = "vid",
- *     "bundle" = "type",
- *     "label" = "title",
- *     "langcode" = "langcode",
- *     "uuid" = "uuid",
- *     "status" = "status",
- *     "published" = "status",
- *     "uid" = "uid",
- *     "owner" = "uid",
- *   },
- *   revision_metadata_keys = {
- *     "revision_user" = "revision_uid",
- *     "revision_created" = "revision_timestamp",
- *     "revision_log_message" = "revision_log"
- *   },
- *   bundle_entity_type = "node_type",
- *   field_ui_base_route = "entity.node_type.edit_form",
- *   common_reference_target = TRUE,
- *   permission_granularity = "bundle",
- *   links = {
- *     "canonical" = "/node/{node}",
- *     "delete-form" = "/node/{node}/delete",
- *     "delete-multiple-form" = "/admin/content/node/delete",
- *     "edit-form" = "/node/{node}/edit",
- *     "version-history" = "/node/{node}/revisions",
- *     "revision" = "/node/{node}/revisions/{node_revision}/view",
- *     "create" = "/node",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'node', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Content'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Content'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('content item'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('content items'), label_count: ['singular' => '@count content item', 'plural' => '@count content items'], bundle_label: new Drupal\Core\StringTranslation\TranslatableMarkup('Content type'), handlers: ['storage' => 'Drupal\node\NodeStorage', 'storage_schema' => 'Drupal\node\NodeStorageSchema', 'view_builder' => 'Drupal\node\NodeViewBuilder', 'access' => 'Drupal\node\NodeAccessControlHandler', 'views_data' => 'Drupal\node\NodeViewsData', 'form' => ['default' => 'Drupal\node\NodeForm', 'delete' => 'Drupal\node\Form\NodeDeleteForm', 'edit' => 'Drupal\node\NodeForm', 'delete-multiple-confirm' => 'Drupal\node\Form\DeleteMultiple'], 'route_provider' => ['html' => 'Drupal\node\Entity\NodeRouteProvider'], 'list_builder' => 'Drupal\node\NodeListBuilder', 'translation' => 'Drupal\node\NodeTranslationHandler'], base_table: 'node', data_table: 'node_field_data', revision_table: 'node_revision', revision_data_table: 'node_field_revision', show_revision_ui: true, translatable: true, list_cache_contexts: ['user.node_grants:view'], entity_keys: ['id' => 'nid', 'revision' => 'vid', 'bundle' => 'type', 'label' => 'title', 'langcode' => 'langcode', 'uuid' => 'uuid', 'status' => 'status', 'published' => 'status', 'uid' => 'uid', 'owner' => 'uid'], revision_metadata_keys: ['revision_user' => 'revision_uid', 'revision_created' => 'revision_timestamp', 'revision_log_message' => 'revision_log'], bundle_entity_type: 'node_type', field_ui_base_route: 'entity.node_type.edit_form', common_reference_target: true, permission_granularity: 'bundle', links: ['canonical' => '/node/{node}', 'delete-form' => '/node/{node}/delete', 'delete-multiple-form' => '/admin/content/node/delete', 'edit-form' => '/node/{node}/edit', 'version-history' => '/node/{node}/revisions', 'revision' => '/node/{node}/revisions/{node_revision}/view', 'create' => '/node'])]
 class Node extends EditorialContentEntityBase implements NodeInterface {
 
   use EntityOwnerTrait;

--- a/core/modules/node/src/Entity/NodeType.php
+++ b/core/modules/node/src/Entity/NodeType.php
@@ -8,53 +8,8 @@ use Drupal\node\NodeTypeInterface;
 
 /**
  * Defines the Node type configuration entity.
- *
- * @ConfigEntityType(
- *   id = "node_type",
- *   label = @Translation("Content type"),
- *   label_collection = @Translation("Content types"),
- *   label_singular = @Translation("content type"),
- *   label_plural = @Translation("content types"),
- *   label_count = @PluralTranslation(
- *     singular = "@count content type",
- *     plural = "@count content types",
- *   ),
- *   handlers = {
- *     "access" = "Drupal\node\NodeTypeAccessControlHandler",
- *     "form" = {
- *       "add" = "Drupal\node\NodeTypeForm",
- *       "edit" = "Drupal\node\NodeTypeForm",
- *       "delete" = "Drupal\node\Form\NodeTypeDeleteConfirm"
- *     },
- *     "route_provider" = {
- *       "permissions" = "Drupal\user\Entity\EntityPermissionsRouteProvider",
- *     },
- *     "list_builder" = "Drupal\node\NodeTypeListBuilder",
- *   },
- *   admin_permission = "administer content types",
- *   config_prefix = "type",
- *   bundle_of = "node",
- *   entity_keys = {
- *     "id" = "type",
- *     "label" = "name"
- *   },
- *   links = {
- *     "edit-form" = "/admin/structure/types/manage/{node_type}",
- *     "delete-form" = "/admin/structure/types/manage/{node_type}/delete",
- *     "entity-permissions-form" = "/admin/structure/types/manage/{node_type}/permissions",
- *     "collection" = "/admin/structure/types",
- *   },
- *   config_export = {
- *     "name",
- *     "type",
- *     "description",
- *     "help",
- *     "new_revision",
- *     "preview_mode",
- *     "display_submitted",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'node_type', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Content type'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Content types'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('content type'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('content types'), label_count: ['singular' => '@count content type', 'plural' => '@count content types'], handlers: ['access' => 'Drupal\node\NodeTypeAccessControlHandler', 'form' => ['add' => 'Drupal\node\NodeTypeForm', 'edit' => 'Drupal\node\NodeTypeForm', 'delete' => 'Drupal\node\Form\NodeTypeDeleteConfirm'], 'route_provider' => ['permissions' => 'Drupal\user\Entity\EntityPermissionsRouteProvider'], 'list_builder' => 'Drupal\node\NodeTypeListBuilder'], admin_permission: 'administer content types', config_prefix: 'type', bundle_of: 'node', entity_keys: ['id' => 'type', 'label' => 'name'], links: ['edit-form' => '/admin/structure/types/manage/{node_type}', 'delete-form' => '/admin/structure/types/manage/{node_type}/delete', 'entity-permissions-form' => '/admin/structure/types/manage/{node_type}/permissions', 'collection' => '/admin/structure/types'], config_export: ['name', 'type', 'description', 'help', 'new_revision', 'preview_mode', 'display_submitted'])]
 class NodeType extends ConfigEntityBundleBase implements NodeTypeInterface {
 
   /**

--- a/core/modules/path_alias/src/Entity/PathAlias.php
+++ b/core/modules/path_alias/src/Entity/PathAlias.php
@@ -13,37 +13,8 @@ use Drupal\path_alias\PathAliasInterface;
 
 /**
  * Defines the path_alias entity class.
- *
- * @ContentEntityType(
- *   id = "path_alias",
- *   label = @Translation("URL alias"),
- *   label_collection = @Translation("URL aliases"),
- *   label_singular = @Translation("URL alias"),
- *   label_plural = @Translation("URL aliases"),
- *   label_count = @PluralTranslation(
- *     singular = "@count URL alias",
- *     plural = "@count URL aliases"
- *   ),
- *   handlers = {
- *     "storage" = "Drupal\path_alias\PathAliasStorage",
- *     "storage_schema" = "Drupal\path_alias\PathAliasStorageSchema",
- *   },
- *   base_table = "path_alias",
- *   revision_table = "path_alias_revision",
- *   entity_keys = {
- *     "id" = "id",
- *     "revision" = "revision_id",
- *     "langcode" = "langcode",
- *     "uuid" = "uuid",
- *     "published" = "status",
- *   },
- *   admin_permission = "administer url aliases",
- *   list_cache_tags = { "route_match" },
- *   constraints = {
- *     "UniquePathAlias" = {}
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'path_alias', label: new Drupal\Core\StringTranslation\TranslatableMarkup('URL alias'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('URL aliases'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('URL alias'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('URL aliases'), label_count: ['singular' => '@count URL alias', 'plural' => '@count URL aliases'], handlers: ['storage' => 'Drupal\path_alias\PathAliasStorage', 'storage_schema' => 'Drupal\path_alias\PathAliasStorageSchema'], base_table: 'path_alias', revision_table: 'path_alias_revision', entity_keys: ['id' => 'id', 'revision' => 'revision_id', 'langcode' => 'langcode', 'uuid' => 'uuid', 'published' => 'status'], admin_permission: 'administer url aliases', list_cache_tags: ['route_match'], constraints: ['UniquePathAlias' => []])]
 class PathAlias extends ContentEntityBase implements PathAliasInterface {
 
   use EntityPublishedTrait;

--- a/core/modules/responsive_image/src/Entity/ResponsiveImageStyle.php
+++ b/core/modules/responsive_image/src/Entity/ResponsiveImageStyle.php
@@ -10,47 +10,8 @@ use Drupal\responsive_image\ResponsiveImageStyleInterface;
 
 /**
  * Defines the responsive image style entity.
- *
- * @ConfigEntityType(
- *   id = "responsive_image_style",
- *   label = @Translation("Responsive image style"),
- *   label_collection = @Translation("Responsive image styles"),
- *   label_singular = @Translation("responsive image style"),
- *   label_plural = @Translation("responsive image styles"),
- *   label_count = @PluralTranslation(
- *     singular = "@count responsive image style",
- *     plural = "@count responsive image styles",
- *   ),
- *   handlers = {
- *     "list_builder" = "Drupal\responsive_image\ResponsiveImageStyleListBuilder",
- *     "form" = {
- *       "edit" = "Drupal\responsive_image\ResponsiveImageStyleForm",
- *       "add" = "Drupal\responsive_image\ResponsiveImageStyleForm",
- *       "delete" = "Drupal\Core\Entity\EntityDeleteForm",
- *       "duplicate" = "Drupal\responsive_image\ResponsiveImageStyleForm"
- *     }
- *   },
- *   admin_permission = "administer responsive images",
- *   config_prefix = "styles",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "image_style_mappings",
- *     "breakpoint_group",
- *     "fallback_image_style",
- *   },
- *   links = {
- *     "edit-form" = "/admin/config/media/responsive-image-style/{responsive_image_style}",
- *     "duplicate-form" = "/admin/config/media/responsive-image-style/{responsive_image_style}/duplicate",
- *     "delete-form" = "/admin/config/media/responsive-image-style/{responsive_image_style}/delete",
- *     "collection" = "/admin/config/media/responsive-image-style",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'responsive_image_style', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Responsive image style'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Responsive image styles'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('responsive image style'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('responsive image styles'), label_count: ['singular' => '@count responsive image style', 'plural' => '@count responsive image styles'], handlers: ['list_builder' => 'Drupal\responsive_image\ResponsiveImageStyleListBuilder', 'form' => ['edit' => 'Drupal\responsive_image\ResponsiveImageStyleForm', 'add' => 'Drupal\responsive_image\ResponsiveImageStyleForm', 'delete' => 'Drupal\Core\Entity\EntityDeleteForm', 'duplicate' => 'Drupal\responsive_image\ResponsiveImageStyleForm']], admin_permission: 'administer responsive images', config_prefix: 'styles', entity_keys: ['id' => 'id', 'label' => 'label'], config_export: ['id', 'label', 'image_style_mappings', 'breakpoint_group', 'fallback_image_style'], links: ['edit-form' => '/admin/config/media/responsive-image-style/{responsive_image_style}', 'duplicate-form' => '/admin/config/media/responsive-image-style/{responsive_image_style}/duplicate', 'delete-form' => '/admin/config/media/responsive-image-style/{responsive_image_style}/delete', 'collection' => '/admin/config/media/responsive-image-style'])]
 class ResponsiveImageStyle extends ConfigEntityBase implements ResponsiveImageStyleInterface {
 
   /**

--- a/core/modules/rest/src/Entity/RestResourceConfig.php
+++ b/core/modules/rest/src/Entity/RestResourceConfig.php
@@ -9,30 +9,8 @@ use Drupal\rest\RestResourceConfigInterface;
 
 /**
  * Defines a RestResourceConfig configuration entity class.
- *
- * @ConfigEntityType(
- *   id = "rest_resource_config",
- *   label = @Translation("REST resource configuration"),
- *   label_collection = @Translation("REST resource configurations"),
- *   label_singular = @Translation("REST resource configuration"),
- *   label_plural = @Translation("REST resource configurations"),
- *   label_count = @PluralTranslation(
- *     singular = "@count REST resource configuration",
- *     plural = "@count REST resource configurations",
- *   ),
- *   config_prefix = "resource",
- *   admin_permission = "administer rest resources",
- *   entity_keys = {
- *     "id" = "id"
- *   },
- *   config_export = {
- *     "id",
- *     "plugin_id",
- *     "granularity",
- *     "configuration"
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'rest_resource_config', label: new Drupal\Core\StringTranslation\TranslatableMarkup('REST resource configuration'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('REST resource configurations'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('REST resource configuration'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('REST resource configurations'), label_count: ['singular' => '@count REST resource configuration', 'plural' => '@count REST resource configurations'], config_prefix: 'resource', admin_permission: 'administer rest resources', entity_keys: ['id' => 'id'], config_export: ['id', 'plugin_id', 'granularity', 'configuration'])]
 class RestResourceConfig extends ConfigEntityBase implements RestResourceConfigInterface {
 
   /**

--- a/core/modules/search/src/Entity/SearchPage.php
+++ b/core/modules/search/src/Entity/SearchPage.php
@@ -12,52 +12,8 @@ use Drupal\search\SearchPageInterface;
 
 /**
  * Defines a configured search page.
- *
- * @ConfigEntityType(
- *   id = "search_page",
- *   label = @Translation("Search page"),
- *   label_collection = @Translation("Search pages"),
- *   label_singular = @Translation("search page"),
- *   label_plural = @Translation("search pages"),
- *   label_count = @PluralTranslation(
- *     singular = "@count search page",
- *     plural = "@count search pages",
- *   ),
- *   handlers = {
- *     "access" = "Drupal\search\SearchPageAccessControlHandler",
- *     "list_builder" = "Drupal\search\SearchPageListBuilder",
- *     "form" = {
- *       "add" = "Drupal\search\Form\SearchPageAddForm",
- *       "edit" = "Drupal\search\Form\SearchPageEditForm",
- *       "delete" = "Drupal\Core\Entity\EntityDeleteForm"
- *     }
- *   },
- *   admin_permission = "administer search",
- *   links = {
- *     "edit-form" = "/admin/config/search/pages/manage/{search_page}",
- *     "delete-form" = "/admin/config/search/pages/manage/{search_page}/delete",
- *     "enable" = "/admin/config/search/pages/manage/{search_page}/enable",
- *     "disable" = "/admin/config/search/pages/manage/{search_page}/disable",
- *     "set-default" = "/admin/config/search/pages/manage/{search_page}/set-default",
- *     "collection" = "/admin/config/search/pages",
- *   },
- *   config_prefix = "page",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label",
- *     "weight" = "weight",
- *     "status" = "status"
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "path",
- *     "weight",
- *     "plugin",
- *     "configuration",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'search_page', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Search page'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Search pages'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('search page'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('search pages'), label_count: ['singular' => '@count search page', 'plural' => '@count search pages'], handlers: ['access' => 'Drupal\search\SearchPageAccessControlHandler', 'list_builder' => 'Drupal\search\SearchPageListBuilder', 'form' => ['add' => 'Drupal\search\Form\SearchPageAddForm', 'edit' => 'Drupal\search\Form\SearchPageEditForm', 'delete' => 'Drupal\Core\Entity\EntityDeleteForm']], admin_permission: 'administer search', links: ['edit-form' => '/admin/config/search/pages/manage/{search_page}', 'delete-form' => '/admin/config/search/pages/manage/{search_page}/delete', 'enable' => '/admin/config/search/pages/manage/{search_page}/enable', 'disable' => '/admin/config/search/pages/manage/{search_page}/disable', 'set-default' => '/admin/config/search/pages/manage/{search_page}/set-default', 'collection' => '/admin/config/search/pages'], config_prefix: 'page', entity_keys: ['id' => 'id', 'label' => 'label', 'weight' => 'weight', 'status' => 'status'], config_export: ['id', 'label', 'path', 'weight', 'plugin', 'configuration'])]
 class SearchPage extends ConfigEntityBase implements SearchPageInterface, EntityWithPluginCollectionInterface {
 
   /**

--- a/core/modules/shortcut/src/Entity/Shortcut.php
+++ b/core/modules/shortcut/src/Entity/Shortcut.php
@@ -14,46 +14,8 @@ use Drupal\shortcut\ShortcutInterface;
  * Defines the shortcut entity class.
  *
  * @property \Drupal\link\LinkItemInterface $link
- *
- * @ContentEntityType(
- *   id = "shortcut",
- *   label = @Translation("Shortcut link"),
- *   label_collection = @Translation("Shortcut links"),
- *   label_singular = @Translation("shortcut link"),
- *   label_plural = @Translation("shortcut links"),
- *   label_count = @PluralTranslation(
- *     singular = "@count shortcut link",
- *     plural = "@count shortcut links",
- *   ),
- *   bundle_label = @Translation("Shortcut set"),
- *   handlers = {
- *     "access" = "Drupal\shortcut\ShortcutAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\shortcut\ShortcutForm",
- *       "add" = "Drupal\shortcut\ShortcutForm",
- *       "edit" = "Drupal\shortcut\ShortcutForm",
- *       "delete" = "Drupal\shortcut\Form\ShortcutDeleteForm"
- *     },
- *   },
- *   base_table = "shortcut",
- *   data_table = "shortcut_field_data",
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "shortcut_set",
- *     "label" = "title",
- *     "langcode" = "langcode",
- *   },
- *   links = {
- *     "canonical" = "/admin/config/user-interface/shortcut/link/{shortcut}",
- *     "delete-form" = "/admin/config/user-interface/shortcut/link/{shortcut}/delete",
- *     "edit-form" = "/admin/config/user-interface/shortcut/link/{shortcut}",
- *   },
- *   list_cache_tags = { "config:shortcut_set_list" },
- *   bundle_entity_type = "shortcut_set"
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'shortcut', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Shortcut link'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Shortcut links'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('shortcut link'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('shortcut links'), label_count: ['singular' => '@count shortcut link', 'plural' => '@count shortcut links'], bundle_label: new Drupal\Core\StringTranslation\TranslatableMarkup('Shortcut set'), handlers: ['access' => 'Drupal\shortcut\ShortcutAccessControlHandler', 'form' => ['default' => 'Drupal\shortcut\ShortcutForm', 'add' => 'Drupal\shortcut\ShortcutForm', 'edit' => 'Drupal\shortcut\ShortcutForm', 'delete' => 'Drupal\shortcut\Form\ShortcutDeleteForm']], base_table: 'shortcut', data_table: 'shortcut_field_data', translatable: true, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'shortcut_set', 'label' => 'title', 'langcode' => 'langcode'], links: ['canonical' => '/admin/config/user-interface/shortcut/link/{shortcut}', 'delete-form' => '/admin/config/user-interface/shortcut/link/{shortcut}/delete', 'edit-form' => '/admin/config/user-interface/shortcut/link/{shortcut}'], list_cache_tags: ['config:shortcut_set_list'], bundle_entity_type: 'shortcut_set')]
 class Shortcut extends ContentEntityBase implements ShortcutInterface {
 
   /**

--- a/core/modules/shortcut/src/Entity/ShortcutSet.php
+++ b/core/modules/shortcut/src/Entity/ShortcutSet.php
@@ -8,47 +8,8 @@ use Drupal\shortcut\ShortcutSetInterface;
 
 /**
  * Defines the Shortcut set configuration entity.
- *
- * @ConfigEntityType(
- *   id = "shortcut_set",
- *   label = @Translation("Shortcut set"),
- *   label_collection = @Translation("Shortcut sets"),
- *   label_singular = @Translation("shortcut set"),
- *   label_plural = @Translation("shortcut sets"),
- *   label_count = @PluralTranslation(
- *     singular = "@count shortcut set",
- *     plural = "@count shortcut sets",
- *   ),
- *   handlers = {
- *     "storage" = "Drupal\shortcut\ShortcutSetStorage",
- *     "access" = "Drupal\shortcut\ShortcutSetAccessControlHandler",
- *     "list_builder" = "Drupal\shortcut\ShortcutSetListBuilder",
- *     "form" = {
- *       "default" = "Drupal\shortcut\ShortcutSetForm",
- *       "add" = "Drupal\shortcut\ShortcutSetForm",
- *       "edit" = "Drupal\shortcut\ShortcutSetForm",
- *       "customize" = "Drupal\shortcut\Form\SetCustomize",
- *       "delete" = "Drupal\shortcut\Form\ShortcutSetDeleteForm"
- *     }
- *   },
- *   config_prefix = "set",
- *   bundle_of = "shortcut",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   },
- *   links = {
- *     "customize-form" = "/admin/config/user-interface/shortcut/manage/{shortcut_set}/customize",
- *     "delete-form" = "/admin/config/user-interface/shortcut/manage/{shortcut_set}/delete",
- *     "edit-form" = "/admin/config/user-interface/shortcut/manage/{shortcut_set}",
- *     "collection" = "/admin/config/user-interface/shortcut",
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'shortcut_set', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Shortcut set'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Shortcut sets'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('shortcut set'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('shortcut sets'), label_count: ['singular' => '@count shortcut set', 'plural' => '@count shortcut sets'], handlers: ['storage' => 'Drupal\shortcut\ShortcutSetStorage', 'access' => 'Drupal\shortcut\ShortcutSetAccessControlHandler', 'list_builder' => 'Drupal\shortcut\ShortcutSetListBuilder', 'form' => ['default' => 'Drupal\shortcut\ShortcutSetForm', 'add' => 'Drupal\shortcut\ShortcutSetForm', 'edit' => 'Drupal\shortcut\ShortcutSetForm', 'customize' => 'Drupal\shortcut\Form\SetCustomize', 'delete' => 'Drupal\shortcut\Form\ShortcutSetDeleteForm']], config_prefix: 'set', bundle_of: 'shortcut', entity_keys: ['id' => 'id', 'label' => 'label'], links: ['customize-form' => '/admin/config/user-interface/shortcut/manage/{shortcut_set}/customize', 'delete-form' => '/admin/config/user-interface/shortcut/manage/{shortcut_set}/delete', 'edit-form' => '/admin/config/user-interface/shortcut/manage/{shortcut_set}', 'collection' => '/admin/config/user-interface/shortcut'], config_export: ['id', 'label'])]
 class ShortcutSet extends ConfigEntityBundleBase implements ShortcutSetInterface {
 
   /**

--- a/core/modules/system/src/Entity/Action.php
+++ b/core/modules/system/src/Entity/Action.php
@@ -11,31 +11,8 @@ use Drupal\Core\Action\ActionPluginCollection;
 
 /**
  * Defines the configured action entity.
- *
- * @ConfigEntityType(
- *   id = "action",
- *   label = @Translation("Action"),
- *   label_collection = @Translation("Actions"),
- *   label_singular = @Translation("action"),
- *   label_plural = @Translation("actions"),
- *   label_count = @PluralTranslation(
- *     singular = "@count action",
- *     plural = "@count actions",
- *   ),
- *   admin_permission = "administer actions",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "type",
- *     "plugin",
- *     "configuration",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'action', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Action'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Actions'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('action'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('actions'), label_count: ['singular' => '@count action', 'plural' => '@count actions'], admin_permission: 'administer actions', entity_keys: ['id' => 'id', 'label' => 'label'], config_export: ['id', 'label', 'type', 'plugin', 'configuration'])]
 class Action extends ConfigEntityBase implements ActionConfigEntityInterface, EntityWithPluginCollectionInterface {
 
   /**

--- a/core/modules/system/src/Entity/Menu.php
+++ b/core/modules/system/src/Entity/Menu.php
@@ -8,34 +8,8 @@ use Drupal\system\MenuInterface;
 
 /**
  * Defines the Menu configuration entity class.
- *
- * @ConfigEntityType(
- *   id = "menu",
- *   label = @Translation("Menu"),
- *   label_collection = @Translation("Menus"),
- *   label_singular = @Translation("menu"),
- *   label_plural = @Translation("menus"),
- *   label_count = @PluralTranslation(
- *     singular = "@count menu",
- *     plural = "@count menus",
- *   ),
- *   handlers = {
- *     "access" = "Drupal\system\MenuAccessControlHandler",
- *     "storage" = "Drupal\system\MenuStorage",
- *   },
- *   admin_permission = "administer menu",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "description",
- *     "locked",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'menu', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Menu'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Menus'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('menu'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('menus'), label_count: ['singular' => '@count menu', 'plural' => '@count menus'], handlers: ['access' => 'Drupal\system\MenuAccessControlHandler', 'storage' => 'Drupal\system\MenuStorage'], admin_permission: 'administer menu', entity_keys: ['id' => 'id', 'label' => 'label'], config_export: ['id', 'label', 'description', 'locked'])]
 class Menu extends ConfigEntityBase implements MenuInterface {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntitySerializedField.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntitySerializedField.php
@@ -7,25 +7,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Defines a test class for testing fields with a serialized column.
- *
- * @ContentEntityType(
- *   id = "entity_test_serialized_field",
- *   label = @Translation("Test serialized fields"),
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name"
- *   },
- *   base_table = "entity_test_serialized_fields",
- *   persistent_cache = FALSE,
- *   serialized_field_property_names = {
- *     "serialized_long" = {
- *       "value"
- *     }
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_serialized_field', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test serialized fields'), entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name'], base_table: 'entity_test_serialized_fields', persistent_cache: false, serialized_field_property_names: ['serialized_long' => ['value']])]
 class EntitySerializedField extends EntityTest {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTest.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTest.php
@@ -11,46 +11,8 @@ use Drupal\user\UserInterface;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test",
- *   label = @Translation("Test entity"),
- *   handlers = {
- *     "list_builder" = "Drupal\entity_test\EntityTestListBuilder",
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilder",
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm",
- *       "delete" = "Drupal\entity_test\EntityTestDeleteForm"
- *     },
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *     "views_data" = "Drupal\entity_test\EntityTestViewsData"
- *   },
- *   base_table = "entity_test",
- *   admin_permission = "administer entity_test content",
- *   persistent_cache = FALSE,
- *   list_cache_contexts = { "entity_test_view_grants" },
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- *   links = {
- *     "canonical" = "/entity_test/{entity_test}",
- *     "add-form" = "/entity_test/add",
- *     "edit-form" = "/entity_test/manage/{entity_test}/edit",
- *     "delete-form" = "/entity_test/delete/entity_test/{entity_test}",
- *   },
- *   field_ui_base_route = "entity.entity_test.admin_form",
- * )
- *
- * Note that this entity type annotation intentionally omits the "create" link
- * template. See https://www.drupal.org/node/2293697.
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity'), handlers: ['list_builder' => 'Drupal\entity_test\EntityTestListBuilder', 'view_builder' => 'Drupal\entity_test\EntityTestViewBuilder', 'access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm', 'delete' => 'Drupal\entity_test\EntityTestDeleteForm'], 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider'], 'views_data' => 'Drupal\entity_test\EntityTestViewsData'], base_table: 'entity_test', admin_permission: 'administer entity_test content', persistent_cache: false, list_cache_contexts: ['entity_test_view_grants'], entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'], links: ['canonical' => '/entity_test/{entity_test}', 'add-form' => '/entity_test/add', 'edit-form' => '/entity_test/manage/{entity_test}/edit', 'delete-form' => '/entity_test/delete/entity_test/{entity_test}'], field_ui_base_route: 'entity.entity_test.admin_form')]
 class EntityTest extends ContentEntityBase implements EntityOwnerInterface {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestAddPage.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestAddPage.php
@@ -4,32 +4,7 @@ namespace Drupal\entity_test\Entity;
 
 /**
  * Test entity class routes.
- *
- * @ContentEntityType(
- *   id = "entity_test_add_page",
- *   label = @Translation("Entity test route add page"),
- *   handlers = {
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm",
- *     },
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *   },
- *   admin_permission = "administer entity_test content",
- *   base_table = "entity_test_add_page",
- *   render_cache = FALSE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *   },
- *   links = {
- *     "add-page" = "/entity_test_add_page/{user}/add",
- *     "add-form" = "/entity_test_add_page/add/{user}/form",
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_add_page', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Entity test route add page'), handlers: ['form' => ['default' => 'Drupal\entity_test\EntityTestForm'], 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider']], admin_permission: 'administer entity_test content', base_table: 'entity_test_add_page', render_cache: false, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name'], links: ['add-page' => '/entity_test_add_page/{user}/add', 'add-form' => '/entity_test_add_page/add/{user}/form'])]
 class EntityTestAddPage extends EntityTest {
 }

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestAdminRoutes.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestAdminRoutes.php
@@ -4,40 +4,8 @@ namespace Drupal\entity_test\Entity;
 
 /**
  * Defines a test entity type with administrative routes.
- *
- * @ContentEntityType(
- *   id = "entity_test_admin_routes",
- *   label = @Translation("Test entity - admin routes"),
- *   handlers = {
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilder",
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm",
- *       "delete" = "Drupal\entity_test\EntityTestDeleteForm"
- *     },
- *     "views_data" = "Drupal\views\EntityViewsData",
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\AdminHtmlRouteProvider",
- *     },
- *   },
- *   base_table = "entity_test_admin_routes",
- *   data_table = "entity_test_admin_routes_property_data",
- *   admin_permission = "administer entity_test content",
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- *   links = {
- *     "canonical" = "/entity_test_admin_routes/manage/{entity_test_admin_routes}",
- *     "edit-form" = "/entity_test_admin_routes/manage/{entity_test_admin_routes}/edit",
- *     "delete-form" = "/entity_test/delete/entity_test_admin_routes/{entity_test_admin_routes}",
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_admin_routes', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - admin routes'), handlers: ['view_builder' => 'Drupal\entity_test\EntityTestViewBuilder', 'access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm', 'delete' => 'Drupal\entity_test\EntityTestDeleteForm'], 'views_data' => 'Drupal\views\EntityViewsData', 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\AdminHtmlRouteProvider']], base_table: 'entity_test_admin_routes', data_table: 'entity_test_admin_routes_property_data', admin_permission: 'administer entity_test content', translatable: true, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'], links: ['canonical' => '/entity_test_admin_routes/manage/{entity_test_admin_routes}', 'edit-form' => '/entity_test_admin_routes/manage/{entity_test_admin_routes}/edit', 'delete-form' => '/entity_test/delete/entity_test_admin_routes/{entity_test_admin_routes}'])]
 class EntityTestAdminRoutes extends EntityTest {
 
 }

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestBaseFieldDisplay.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestBaseFieldDisplay.php
@@ -8,37 +8,8 @@ use Drupal\entity_test\FieldStorageDefinition;
 
 /**
  * Defines a test entity class for base fields display.
- *
- * @ContentEntityType(
- *   id = "entity_test_base_field_display",
- *   label = @Translation("Test entity - base field display"),
- *   handlers = {
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm"
- *     },
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *   },
- *   base_table = "entity_test_base_field_display",
- *   admin_permission = "administer entity_test content",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "name",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "langcode" = "langcode",
- *   },
- *   links = {
- *     "canonical" = "/entity_test_base_field_display/{entity_test_base_field_display}/edit",
- *     "add-form" = "/entity_test_base_field_display/add",
- *     "edit-form" = "/entity_test_base_field_display/manage/{entity_test_base_field_display}",
- *     "delete-form" = "/entity_test/delete/entity_test_base_field_display/{entity_test_base_field_display}/edit",
- *   },
- *   field_ui_base_route = "entity.entity_test_base_field_display.admin_form",
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_base_field_display', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - base field display'), handlers: ['access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm'], 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider']], base_table: 'entity_test_base_field_display', admin_permission: 'administer entity_test content', entity_keys: ['id' => 'id', 'label' => 'name', 'uuid' => 'uuid', 'bundle' => 'type', 'langcode' => 'langcode'], links: ['canonical' => '/entity_test_base_field_display/{entity_test_base_field_display}/edit', 'add-form' => '/entity_test_base_field_display/add', 'edit-form' => '/entity_test_base_field_display/manage/{entity_test_base_field_display}', 'delete-form' => '/entity_test/delete/entity_test_base_field_display/{entity_test_base_field_display}/edit'], field_ui_base_route: 'entity.entity_test_base_field_display.admin_form')]
 class EntityTestBaseFieldDisplay extends EntityTest {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestBundle.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestBundle.php
@@ -7,36 +7,8 @@ use Drupal\Core\Entity\EntityDescriptionInterface;
 
 /**
  * Defines the Test entity bundle configuration entity.
- *
- * @ConfigEntityType(
- *   id = "entity_test_bundle",
- *   label = @Translation("Test entity bundle"),
- *   handlers = {
- *     "access" = "\Drupal\Core\Entity\EntityAccessControlHandler",
- *     "form" = {
- *       "default" = "\Drupal\Core\Entity\BundleEntityFormBase",
- *     },
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *   },
- *   admin_permission = "administer entity_test_bundle content",
- *   config_prefix = "entity_test_bundle",
- *   bundle_of = "entity_test_with_bundle",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "description",
- *   },
- *   links = {
- *     "add-form" = "/entity_test_bundle/add",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'entity_test_bundle', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity bundle'), handlers: ['access' => '\Drupal\Core\Entity\EntityAccessControlHandler', 'form' => ['default' => '\Drupal\Core\Entity\BundleEntityFormBase'], 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider']], admin_permission: 'administer entity_test_bundle content', config_prefix: 'entity_test_bundle', bundle_of: 'entity_test_with_bundle', entity_keys: ['id' => 'id', 'label' => 'label'], config_export: ['id', 'label', 'description'], links: ['add-form' => '/entity_test_bundle/add'])]
 class EntityTestBundle extends ConfigEntityBundleBase implements EntityDescriptionInterface {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestCache.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestCache.php
@@ -4,24 +4,8 @@ namespace Drupal\entity_test\Entity;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_cache",
- *   label = @Translation("Test entity with field cache"),
- *   handlers = {
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm"
- *     },
- *   },
- *   base_table = "entity_test_cache",
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type"
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_cache', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity with field cache'), handlers: ['access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm']], base_table: 'entity_test_cache', entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type'])]
 class EntityTestCache extends EntityTest {
 
 }

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestCompositeConstraint.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestCompositeConstraint.php
@@ -6,29 +6,8 @@ use Drupal\Core\Entity\EntityTypeInterface;
 
 /**
  * Defines a test class for testing composite constraints.
- *
- * @ContentEntityType(
- *   id = "entity_test_composite_constraint",
- *   label = @Translation("Test entity constraints with composite constraint"),
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name"
- *   },
- *   handlers = {
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm"
- *     }
- *   },
- *   base_table = "entity_test_composite_constraint",
- *   persistent_cache = FALSE,
- *   constraints = {
- *     "EntityTestComposite" = {},
- *     "EntityTestEntityLevel" = {},
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_composite_constraint', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity constraints with composite constraint'), entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name'], handlers: ['form' => ['default' => 'Drupal\entity_test\EntityTestForm']], base_table: 'entity_test_composite_constraint', persistent_cache: false, constraints: ['EntityTestComposite' => [], 'EntityTestEntityLevel' => []])]
 class EntityTestCompositeConstraint extends EntityTest {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestComputedField.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestComputedField.php
@@ -11,25 +11,8 @@ use Drupal\entity_test\Plugin\Field\ComputedTestFieldItemList;
 
 /**
  * An entity used for testing computed field values.
- *
- * @ContentEntityType(
- *   id = "entity_test_computed_field",
- *   label = @Translation("Entity Test computed field"),
- *   base_table = "entity_test_computed_field",
- *   handlers = {
- *     "views_data" = "Drupal\entity_test\EntityTestViewsData"
- *   },
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "label" = "name",
- *   },
- *   admin_permission = "administer entity_test content",
- *   links = {
- *     "canonical" = "/entity_test_computed_field/{entity_test_computed_field}",
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_computed_field', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Entity Test computed field'), base_table: 'entity_test_computed_field', handlers: ['views_data' => 'Drupal\entity_test\EntityTestViewsData'], entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'name'], admin_permission: 'administer entity_test content', links: ['canonical' => '/entity_test_computed_field/{entity_test_computed_field}'])]
 class EntityTestComputedField extends EntityTest {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestConstraintViolation.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestConstraintViolation.php
@@ -7,25 +7,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Defines the test entity class for testing entity constraint violations.
- *
- * @ContentEntityType(
- *   id = "entity_test_constraint_violation",
- *   label = @Translation("Test entity constraint violation"),
- *   handlers = {
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm"
- *     }
- *   },
- *   base_table = "entity_test_constraint_violation",
- *   persistent_cache = FALSE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name"
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_constraint_violation', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity constraint violation'), handlers: ['form' => ['default' => 'Drupal\entity_test\EntityTestForm']], base_table: 'entity_test_constraint_violation', persistent_cache: false, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name'])]
 class EntityTestConstraintViolation extends EntityTest {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestConstraints.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestConstraints.php
@@ -9,23 +9,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Defines a test class for testing the definition of entity level constraints.
- *
- * @ContentEntityType(
- *   id = "entity_test_constraints",
- *   label = @Translation("Test entity constraints"),
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name"
- *   },
- *   base_table = "entity_test_constraints",
- *   persistent_cache = FALSE,
- *   constraints = {
- *     "NotNull" = {}
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_constraints', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity constraints'), entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name'], base_table: 'entity_test_constraints', persistent_cache: false, constraints: ['NotNull' => []])]
 class EntityTestConstraints extends EntityTest implements EntityChangedInterface {
 
   use EntityChangedTrait;

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestDefaultAccess.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestDefaultAccess.php
@@ -4,17 +4,8 @@ namespace Drupal\entity_test\Entity;
 
 /**
  * Defines a test entity class with no access control handler.
- *
- * @ContentEntityType(
- *   id = "entity_test_default_access",
- *   label = @Translation("Test entity with default access"),
- *   base_table = "entity_test_default_access",
- *   entity_keys = {
- *     "id" = "id",
- *     "bundle" = "type"
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_default_access', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity with default access'), base_table: 'entity_test_default_access', entity_keys: ['id' => 'id', 'bundle' => 'type'])]
 class EntityTestDefaultAccess extends EntityTest {
 
 }

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestDefaultValue.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestDefaultValue.php
@@ -7,19 +7,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Defines a test entity class for testing default values.
- *
- * @ContentEntityType(
- *   id = "entity_test_default_value",
- *   label = @Translation("Test entity for default values"),
- *   base_table = "entity_test_default_value",
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "langcode" = "langcode"
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_default_value', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity for default values'), base_table: 'entity_test_default_value', entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'langcode' => 'langcode'])]
 class EntityTestDefaultValue extends EntityTest {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestExternal.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestExternal.php
@@ -6,21 +6,8 @@ use Drupal\Core\Url;
 
 /**
  * Test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_external",
- *   label = @Translation("Entity test external"),
- *   base_table = "entity_test_external",
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *   },
- *   links = {
- *     "canonical" = "/entity_test_external/{entity_test_external}"
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_external', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Entity test external'), base_table: 'entity_test_external', entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type'], links: ['canonical' => '/entity_test_external/{entity_test_external}'])]
 class EntityTestExternal extends EntityTest {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestFieldMethods.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestFieldMethods.php
@@ -7,35 +7,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_field_methods",
- *   label = @Translation("Test entity - field methods and data table"),
- *   handlers = {
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilder",
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm",
- *       "delete" = "Drupal\entity_test\EntityTestDeleteForm"
- *     },
- *     "views_data" = "Drupal\views\EntityViewsData",
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *   },
- *   base_table = "entity_test_field_methods",
- *   data_table = "entity_test_field_methods_property",
- *   admin_permission = "administer entity_test content",
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_field_methods', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - field methods and data table'), handlers: ['view_builder' => 'Drupal\entity_test\EntityTestViewBuilder', 'access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm', 'delete' => 'Drupal\entity_test\EntityTestDeleteForm'], 'views_data' => 'Drupal\views\EntityViewsData', 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider']], base_table: 'entity_test_field_methods', data_table: 'entity_test_field_methods_property', admin_permission: 'administer entity_test content', translatable: true, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'])]
 class EntityTestFieldMethods extends EntityTestMul {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestFieldOverride.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestFieldOverride.php
@@ -6,18 +6,8 @@ use Drupal\Core\Entity\EntityTypeInterface;
 
 /**
  * Defines a test entity class for testing default values.
- *
- * @ContentEntityType(
- *   id = "entity_test_field_override",
- *   label = @Translation("Test entity field overrides"),
- *   base_table = "entity_test_field_override",
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type"
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_field_override', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity field overrides'), base_table: 'entity_test_field_override', entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type'])]
 class EntityTestFieldOverride extends EntityTest {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestLabel.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestLabel.php
@@ -4,25 +4,8 @@ namespace Drupal\entity_test\Entity;
 
 /**
  * Test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_label",
- *   label = @Translation("Entity Test label"),
- *   handlers = {
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilder"
- *   },
- *   base_table = "entity_test_label",
- *   render_cache = FALSE,
- *   entity_keys = {
- *     "uuid" = "uuid",
- *     "id" = "id",
- *     "label" = "name",
- *     "bundle" = "type",
- *     "langcode" = "langcode",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_label', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Entity Test label'), handlers: ['access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'view_builder' => 'Drupal\entity_test\EntityTestViewBuilder'], base_table: 'entity_test_label', render_cache: false, entity_keys: ['uuid' => 'uuid', 'id' => 'id', 'label' => 'name', 'bundle' => 'type', 'langcode' => 'langcode'])]
 class EntityTestLabel extends EntityTest {
 
 }

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMapField.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMapField.php
@@ -7,20 +7,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * An entity used for testing map base field values.
- *
- * @ContentEntityType(
- *   id = "entity_test_map_field",
- *   label = @Translation("Entity Test map field"),
- *   base_table = "entity_test_map_field",
- *   entity_keys = {
- *     "uuid" = "uuid",
- *     "id" = "id",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- *   admin_permission = "administer entity_test content",
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_map_field', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Entity Test map field'), base_table: 'entity_test_map_field', entity_keys: ['uuid' => 'uuid', 'id' => 'id', 'label' => 'name', 'langcode' => 'langcode'], admin_permission: 'administer entity_test content')]
 class EntityTestMapField extends EntityTest {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMul.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMul.php
@@ -6,43 +6,8 @@ use Drupal\Core\Entity\EntityTypeInterface;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_mul",
- *   label = @Translation("Test entity - data table"),
- *   handlers = {
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilder",
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm",
- *       "delete" = "Drupal\entity_test\EntityTestDeleteForm"
- *     },
- *     "views_data" = "Drupal\views\EntityViewsData",
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *   },
- *   base_table = "entity_test_mul",
- *   data_table = "entity_test_mul_property_data",
- *   admin_permission = "administer entity_test content",
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- *   links = {
- *     "add-page" = "/entity_test_mul/add",
- *     "add-form" = "/entity_test_mul/add/{type}",
- *     "canonical" = "/entity_test_mul/manage/{entity_test_mul}",
- *     "edit-form" = "/entity_test_mul/manage/{entity_test_mul}/edit",
- *     "delete-form" = "/entity_test/delete/entity_test_mul/{entity_test_mul}",
- *   },
- *   field_ui_base_route = "entity.entity_test_mul.admin_form",
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_mul', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - data table'), handlers: ['view_builder' => 'Drupal\entity_test\EntityTestViewBuilder', 'access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm', 'delete' => 'Drupal\entity_test\EntityTestDeleteForm'], 'views_data' => 'Drupal\views\EntityViewsData', 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider']], base_table: 'entity_test_mul', data_table: 'entity_test_mul_property_data', admin_permission: 'administer entity_test content', translatable: true, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'], links: ['add-page' => '/entity_test_mul/add', 'add-form' => '/entity_test_mul/add/{type}', 'canonical' => '/entity_test_mul/manage/{entity_test_mul}', 'edit-form' => '/entity_test_mul/manage/{entity_test_mul}/edit', 'delete-form' => '/entity_test/delete/entity_test_mul/{entity_test_mul}'], field_ui_base_route: 'entity.entity_test_mul.admin_form')]
 class EntityTestMul extends EntityTest {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulBundle.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulBundle.php
@@ -7,35 +7,8 @@ use Drupal\Core\Entity\EntityDescriptionInterface;
 
 /**
  * Defines the Test entity mul bundle configuration entity.
- *
- * @ConfigEntityType(
- *   id = "entity_test_mul_bundle",
- *   label = @Translation("Test entity multilingual bundle"),
- *   handlers = {
- *     "access" = "\Drupal\Core\Entity\EntityAccessControlHandler",
- *     "form" = {
- *       "default" = "\Drupal\Core\Entity\BundleEntityFormBase",
- *     },
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *   },
- *   admin_permission = "administer entity_test_mul_with_bundle content",
- *   bundle_of = "entity_test_mul_with_bundle",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "description",
- *   },
- *   links = {
- *     "add-form" = "/entity_test_mul_bundle/add",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'entity_test_mul_bundle', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity multilingual bundle'), handlers: ['access' => '\Drupal\Core\Entity\EntityAccessControlHandler', 'form' => ['default' => '\Drupal\Core\Entity\BundleEntityFormBase'], 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider']], admin_permission: 'administer entity_test_mul_with_bundle content', bundle_of: 'entity_test_mul_with_bundle', entity_keys: ['id' => 'id', 'label' => 'label'], config_export: ['id', 'label', 'description'], links: ['add-form' => '/entity_test_mul_bundle/add'])]
 class EntityTestMulBundle extends ConfigEntityBundleBase implements EntityDescriptionInterface {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulChanged.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulChanged.php
@@ -9,41 +9,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_mul_changed",
- *   label = @Translation("Test entity - multiple changed and data table"),
- *   handlers = {
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilder",
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm",
- *       "delete" = "Drupal\entity_test\EntityTestDeleteForm"
- *     },
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *     "views_data" = "Drupal\views\EntityViewsData"
- *   },
- *   base_table = "entity_test_mul_changed",
- *   data_table = "entity_test_mul_changed_property",
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode"
- *   },
- *   links = {
- *     "add-form" = "/entity_test_mul_changed/add",
- *     "canonical" = "/entity_test_mul_changed/manage/{entity_test_mul_changed}",
- *     "edit-form" = "/entity_test_mul_changed/manage/{entity_test_mul_changed}/edit",
- *     "delete-form" = "/entity_test/delete/entity_test_mul_changed/{entity_test_mul_changed}",
- *   },
- *   field_ui_base_route = "entity.entity_test_mul_changed.admin_form",
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_mul_changed', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - multiple changed and data table'), handlers: ['view_builder' => 'Drupal\entity_test\EntityTestViewBuilder', 'access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm', 'delete' => 'Drupal\entity_test\EntityTestDeleteForm'], 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider'], 'views_data' => 'Drupal\views\EntityViewsData'], base_table: 'entity_test_mul_changed', data_table: 'entity_test_mul_changed_property', translatable: true, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'], links: ['add-form' => '/entity_test_mul_changed/add', 'canonical' => '/entity_test_mul_changed/manage/{entity_test_mul_changed}', 'edit-form' => '/entity_test_mul_changed/manage/{entity_test_mul_changed}/edit', 'delete-form' => '/entity_test/delete/entity_test_mul_changed/{entity_test_mul_changed}'], field_ui_base_route: 'entity.entity_test_mul_changed.admin_form')]
 class EntityTestMulChanged extends EntityTestMul implements EntityChangedInterface {
 
   use EntityChangedTrait;

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulDefaultValue.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulDefaultValue.php
@@ -7,37 +7,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_mul_default_value",
- *   label = @Translation("Test entity - multiple default value and data table"),
- *   handlers = {
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilder",
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm",
- *       "delete" = "Drupal\entity_test\EntityTestDeleteForm"
- *     },
- *     "views_data" = "Drupal\views\EntityViewsData"
- *   },
- *   base_table = "entity_test_mul_default_value",
- *   data_table = "entity_test_mul_default_value_property_data",
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode"
- *   },
- *   links = {
- *     "canonical" = "/entity_test_mul_default_value/manage/{entity_test_mul_default_value}",
- *     "edit-form" = "/entity_test_mul_default_value/manage/{entity_test_mul_default_value}",
- *     "delete-form" = "/entity_test/delete/entity_test_mul_default_value/{entity_test_mul_default_value}",
- *   },
- *   field_ui_base_route = "entity.entity_test_mul.admin_form",
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_mul_default_value', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - multiple default value and data table'), handlers: ['view_builder' => 'Drupal\entity_test\EntityTestViewBuilder', 'access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm', 'delete' => 'Drupal\entity_test\EntityTestDeleteForm'], 'views_data' => 'Drupal\views\EntityViewsData'], base_table: 'entity_test_mul_default_value', data_table: 'entity_test_mul_default_value_property_data', translatable: true, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'], links: ['canonical' => '/entity_test_mul_default_value/manage/{entity_test_mul_default_value}', 'edit-form' => '/entity_test_mul_default_value/manage/{entity_test_mul_default_value}', 'delete-form' => '/entity_test/delete/entity_test_mul_default_value/{entity_test_mul_default_value}'], field_ui_base_route: 'entity.entity_test_mul.admin_form')]
 class EntityTestMulDefaultValue extends EntityTestMul {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulLangcodeKey.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulLangcodeKey.php
@@ -4,43 +4,8 @@ namespace Drupal\entity_test\Entity;
 
 /**
  * Defines a test entity class using a custom langcode entity key.
- *
- * @ContentEntityType(
- *   id = "entity_test_mul_langcode_key",
- *   label = @Translation("Test entity - data table - langcode key"),
- *   handlers = {
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilder",
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm",
- *       "delete" = "Drupal\entity_test\EntityTestDeleteForm"
- *     },
- *     "views_data" = "Drupal\views\EntityViewsData",
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *   },
- *   base_table = "entity_test_mul_langcode_key",
- *   data_table = "entity_test_mul_langcode_key_field_data",
- *   admin_permission = "administer entity_test content",
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "custom_langcode_key",
- *     "default_langcode" = "custom_default_langcode_key",
- *   },
- *   links = {
- *     "add-form" = "/entity_test_mul_langcode_key/add",
- *     "canonical" = "/entity_test_mul_langcode_key/manage/{entity_test_mul_langcode_key}",
- *     "edit-form" = "/entity_test_mul_langcode_key/manage/{entity_test_mul_langcode_key}/edit",
- *     "delete-form" = "/entity_test/delete/entity_test_mul_langcode_key/{entity_test_mul_langcode_key}",
- *   },
- *   field_ui_base_route = "entity.entity_test_mul_langcode_key.admin_form",
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_mul_langcode_key', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - data table - langcode key'), handlers: ['view_builder' => 'Drupal\entity_test\EntityTestViewBuilder', 'access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm', 'delete' => 'Drupal\entity_test\EntityTestDeleteForm'], 'views_data' => 'Drupal\views\EntityViewsData', 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider']], base_table: 'entity_test_mul_langcode_key', data_table: 'entity_test_mul_langcode_key_field_data', admin_permission: 'administer entity_test content', translatable: true, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'custom_langcode_key', 'default_langcode' => 'custom_default_langcode_key'], links: ['add-form' => '/entity_test_mul_langcode_key/add', 'canonical' => '/entity_test_mul_langcode_key/manage/{entity_test_mul_langcode_key}', 'edit-form' => '/entity_test_mul_langcode_key/manage/{entity_test_mul_langcode_key}/edit', 'delete-form' => '/entity_test/delete/entity_test_mul_langcode_key/{entity_test_mul_langcode_key}'], field_ui_base_route: 'entity.entity_test_mul_langcode_key.admin_form')]
 class EntityTestMulLangcodeKey extends EntityTest {
 
 }

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulRev.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulRev.php
@@ -7,46 +7,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_mulrev",
- *   label = @Translation("Test entity - mul revisions and data table"),
- *   handlers = {
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilder",
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm",
- *       "delete" = "Drupal\entity_test\EntityTestDeleteForm"
- *     },
- *     "views_data" = "Drupal\views\EntityViewsData",
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *   },
- *   base_table = "entity_test_mulrev",
- *   data_table = "entity_test_mulrev_property_data",
- *   revision_table = "entity_test_mulrev_revision",
- *   revision_data_table = "entity_test_mulrev_property_revision",
- *   admin_permission = "administer entity_test content",
- *   translatable = TRUE,
- *   show_revision_ui = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "revision" = "revision_id",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- *   links = {
- *     "add-form" = "/entity_test_mulrev/add",
- *     "canonical" = "/entity_test_mulrev/manage/{entity_test_mulrev}",
- *     "delete-form" = "/entity_test/delete/entity_test_mulrev/{entity_test_mulrev}",
- *     "edit-form" = "/entity_test_mulrev/manage/{entity_test_mulrev}/edit",
- *     "revision" = "/entity_test_mulrev/{entity_test_mulrev}/revision/{entity_test_mulrev_revision}/view",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_mulrev', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - mul revisions and data table'), handlers: ['view_builder' => 'Drupal\entity_test\EntityTestViewBuilder', 'access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm', 'delete' => 'Drupal\entity_test\EntityTestDeleteForm'], 'views_data' => 'Drupal\views\EntityViewsData', 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider']], base_table: 'entity_test_mulrev', data_table: 'entity_test_mulrev_property_data', revision_table: 'entity_test_mulrev_revision', revision_data_table: 'entity_test_mulrev_property_revision', admin_permission: 'administer entity_test content', translatable: true, show_revision_ui: true, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'revision' => 'revision_id', 'label' => 'name', 'langcode' => 'langcode'], links: ['add-form' => '/entity_test_mulrev/add', 'canonical' => '/entity_test_mulrev/manage/{entity_test_mulrev}', 'delete-form' => '/entity_test/delete/entity_test_mulrev/{entity_test_mulrev}', 'edit-form' => '/entity_test_mulrev/manage/{entity_test_mulrev}/edit', 'revision' => '/entity_test_mulrev/{entity_test_mulrev}/revision/{entity_test_mulrev_revision}/view'])]
 class EntityTestMulRev extends EntityTestRev {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulRevChanged.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulRevChanged.php
@@ -7,44 +7,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_mulrev_changed",
- *   label = @Translation("Test entity - mul changed revisions and data table"),
- *   handlers = {
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilder",
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm",
- *       "delete" = "Drupal\entity_test\EntityTestDeleteForm"
- *     },
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *     "views_data" = "Drupal\views\EntityViewsData"
- *   },
- *   base_table = "entity_test_mulrev_changed",
- *   data_table = "entity_test_mulrev_changed_property",
- *   revision_table = "entity_test_mulrev_changed_revision",
- *   revision_data_table = "entity_test_mulrev_changed_property_revision",
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "revision" = "revision_id",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- *   links = {
- *     "add-form" = "/entity_test_mulrev_changed/add",
- *     "canonical" = "/entity_test_mulrev_changed/manage/{entity_test_mulrev_changed}",
- *     "delete-form" = "/entity_test/delete/entity_test_mulrev_changed/{entity_test_mulrev_changed}",
- *     "edit-form" = "/entity_test_mulrev_changed/manage/{entity_test_mulrev_changed}/edit",
- *     "revision" = "/entity_test_mulrev_changed/{entity_test_mulrev_changed}/revision/{entity_test_mulrev_changed_revision}/view",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_mulrev_changed', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - mul changed revisions and data table'), handlers: ['view_builder' => 'Drupal\entity_test\EntityTestViewBuilder', 'access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm', 'delete' => 'Drupal\entity_test\EntityTestDeleteForm'], 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider'], 'views_data' => 'Drupal\views\EntityViewsData'], base_table: 'entity_test_mulrev_changed', data_table: 'entity_test_mulrev_changed_property', revision_table: 'entity_test_mulrev_changed_revision', revision_data_table: 'entity_test_mulrev_changed_property_revision', translatable: true, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'revision' => 'revision_id', 'label' => 'name', 'langcode' => 'langcode'], links: ['add-form' => '/entity_test_mulrev_changed/add', 'canonical' => '/entity_test_mulrev_changed/manage/{entity_test_mulrev_changed}', 'delete-form' => '/entity_test/delete/entity_test_mulrev_changed/{entity_test_mulrev_changed}', 'edit-form' => '/entity_test_mulrev_changed/manage/{entity_test_mulrev_changed}/edit', 'revision' => '/entity_test_mulrev_changed/{entity_test_mulrev_changed}/revision/{entity_test_mulrev_changed_revision}/view'])]
 class EntityTestMulRevChanged extends EntityTestMulChanged {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulRevChangedWithRevisionLog.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulRevChangedWithRevisionLog.php
@@ -8,27 +8,8 @@ use Drupal\Core\Entity\RevisionLogInterface;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_mulrev_changed_rev",
- *   label = @Translation("Test entity - revisions log and data table"),
- *   base_table = "entity_test_mulrev_changed_revlog",
- *   revision_table = "entity_test_mulrev_changed_revlog_revision",
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "revision" = "revision_id",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- *   revision_metadata_keys = {
- *     "revision_user" = "revision_user",
- *     "revision_created" = "revision_created",
- *     "revision_log_message" = "revision_log_message"
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_mulrev_changed_rev', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - revisions log and data table'), base_table: 'entity_test_mulrev_changed_revlog', revision_table: 'entity_test_mulrev_changed_revlog_revision', entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'revision' => 'revision_id', 'label' => 'name', 'langcode' => 'langcode'], revision_metadata_keys: ['revision_user' => 'revision_user', 'revision_created' => 'revision_created', 'revision_log_message' => 'revision_log_message'])]
 class EntityTestMulRevChangedWithRevisionLog extends EntityTestMulRevChanged implements RevisionLogInterface {
 
   use RevisionLogEntityTrait;

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulRevPub.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulRevPub.php
@@ -8,49 +8,8 @@ use Drupal\Core\Entity\EntityTypeInterface;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_mulrevpub",
- *   label = @Translation("Test entity - revisions, data table, and published interface"),
- *   handlers = {
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilder",
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm",
- *       "delete" = "Drupal\entity_test\EntityTestDeleteForm",
- *       "delete-multiple-confirm" = "Drupal\Core\Entity\Form\DeleteMultipleForm"
- *     },
- *     "views_data" = "Drupal\views\EntityViewsData",
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *   },
- *   base_table = "entity_test_mulrevpub",
- *   data_table = "entity_test_mulrevpub_property_data",
- *   revision_table = "entity_test_mulrevpub_revision",
- *   revision_data_table = "entity_test_mulrevpub_property_revision",
- *   admin_permission = "administer entity_test content",
- *   translatable = TRUE,
- *   show_revision_ui = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "revision" = "revision_id",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *     "published" = "status",
- *   },
- *   links = {
- *     "add-form" = "/entity_test_mulrevpub/add",
- *     "canonical" = "/entity_test_mulrevpub/manage/{entity_test_mulrevpub}",
- *     "delete-form" = "/entity_test/delete/entity_test_mulrevpub/{entity_test_mulrevpub}",
- *     "delete-multiple-form" = "/entity_test/delete",
- *     "edit-form" = "/entity_test_mulrevpub/manage/{entity_test_mulrevpub}/edit",
- *     "revision" = "/entity_test_mulrevpub/{entity_test_mulrevpub}/revision/{entity_test_mulrevpub_revision}/view",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_mulrevpub', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - revisions, data table, and published interface'), handlers: ['view_builder' => 'Drupal\entity_test\EntityTestViewBuilder', 'access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm', 'delete' => 'Drupal\entity_test\EntityTestDeleteForm', 'delete-multiple-confirm' => 'Drupal\Core\Entity\Form\DeleteMultipleForm'], 'views_data' => 'Drupal\views\EntityViewsData', 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider']], base_table: 'entity_test_mulrevpub', data_table: 'entity_test_mulrevpub_property_data', revision_table: 'entity_test_mulrevpub_revision', revision_data_table: 'entity_test_mulrevpub_property_revision', admin_permission: 'administer entity_test content', translatable: true, show_revision_ui: true, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'revision' => 'revision_id', 'label' => 'name', 'langcode' => 'langcode', 'published' => 'status'], links: ['add-form' => '/entity_test_mulrevpub/add', 'canonical' => '/entity_test_mulrevpub/manage/{entity_test_mulrevpub}', 'delete-form' => '/entity_test/delete/entity_test_mulrevpub/{entity_test_mulrevpub}', 'delete-multiple-form' => '/entity_test/delete', 'edit-form' => '/entity_test_mulrevpub/manage/{entity_test_mulrevpub}/edit', 'revision' => '/entity_test_mulrevpub/{entity_test_mulrevpub}/revision/{entity_test_mulrevpub_revision}/view'])]
 class EntityTestMulRevPub extends EntityTestMulRev implements EntityPublishedInterface {
 
   use EntityPublishedTrait;

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulWithBundle.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMulWithBundle.php
@@ -4,46 +4,8 @@ namespace Drupal\entity_test\Entity;
 
 /**
  * Defines the multilingual test entity class with bundles.
- *
- * @ContentEntityType(
- *   id = "entity_test_mul_with_bundle",
- *   label = @Translation("Test entity multilingual with bundle - data table"),
- *   handlers = {
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilder",
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm",
- *       "delete" = "Drupal\entity_test\EntityTestDeleteForm"
- *     },
- *     "translation" = "Drupal\content_translation\ContentTranslationHandler",
- *     "views_data" = "Drupal\views\EntityViewsData",
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *   },
- *   base_table = "entity_test_mul_with_bundle",
- *   data_table = "entity_test_mul_with_bundle_property_data",
- *   admin_permission = "administer entity_test content",
- *   translatable = TRUE,
- *   permission_granularity = "bundle",
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- *   bundle_entity_type = "entity_test_mul_bundle",
- *   links = {
- *     "add-page" = "/entity_test_mul_with_bundle/add",
- *     "add-form" = "/entity_test_mul_with_bundle/add/{type}",
- *     "canonical" = "/entity_test_mul_with_bundle/manage/{entity_test_mul}",
- *     "edit-form" = "/entity_test_mul_with_bundle/manage/{entity_test_mul}/edit",
- *     "delete-form" = "/entity_test/delete/entity_test_mul_with_bundle/{entity_test_mul}",
- *   },
- *   field_ui_base_route = "entity.entity_test_mul_with_bundle.admin_form",
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_mul_with_bundle', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity multilingual with bundle - data table'), handlers: ['view_builder' => 'Drupal\entity_test\EntityTestViewBuilder', 'access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm', 'delete' => 'Drupal\entity_test\EntityTestDeleteForm'], 'translation' => 'Drupal\content_translation\ContentTranslationHandler', 'views_data' => 'Drupal\views\EntityViewsData', 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider']], base_table: 'entity_test_mul_with_bundle', data_table: 'entity_test_mul_with_bundle_property_data', admin_permission: 'administer entity_test content', translatable: true, permission_granularity: 'bundle', entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'], bundle_entity_type: 'entity_test_mul_bundle', links: ['add-page' => '/entity_test_mul_with_bundle/add', 'add-form' => '/entity_test_mul_with_bundle/add/{type}', 'canonical' => '/entity_test_mul_with_bundle/manage/{entity_test_mul}', 'edit-form' => '/entity_test_mul_with_bundle/manage/{entity_test_mul}/edit', 'delete-form' => '/entity_test/delete/entity_test_mul_with_bundle/{entity_test_mul}'], field_ui_base_route: 'entity.entity_test_mul_with_bundle.admin_form')]
 class EntityTestMulWithBundle extends EntityTest {
 
 }

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMultiValueBasefield.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestMultiValueBasefield.php
@@ -6,24 +6,8 @@ use Drupal\Core\Entity\EntityTypeInterface;
 
 /**
  * Defines an entity type with a multivalue base field.
- *
- * @ContentEntityType(
- *   id = "entity_test_multivalue_basefield",
- *   label = @Translation("Entity Test with a multivalue base field"),
- *   base_table = "entity_test_multivalue_basefield",
- *   data_table = "entity_test_multivalue_basefield_field_data",
- *   handlers = {
- *     "views_data" = "Drupal\views\EntityViewsData",
- *   },
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_multivalue_basefield', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Entity Test with a multivalue base field'), base_table: 'entity_test_multivalue_basefield', data_table: 'entity_test_multivalue_basefield_field_data', handlers: ['views_data' => 'Drupal\views\EntityViewsData'], entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'])]
 class EntityTestMultiValueBasefield extends EntityTest {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestNew.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestNew.php
@@ -7,19 +7,7 @@ namespace Drupal\entity_test\Entity;
  *
  * This entity type is initially not defined. It is enabled when needed to test
  * the related updates.
- *
- * @ContentEntityType(
- *   id = "entity_test_new",
- *   label = @Translation("New test entity"),
- *   base_table = "entity_test_new",
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_new', label: new Drupal\Core\StringTranslation\TranslatableMarkup('New test entity'), base_table: 'entity_test_new', entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'])]
 class EntityTestNew extends EntityTest {
 }

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestNoBundle.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestNoBundle.php
@@ -4,24 +4,8 @@ namespace Drupal\entity_test\Entity;
 
 /**
  * Test entity class with no bundle.
- *
- * @ContentEntityType(
- *   id = "entity_test_no_bundle",
- *   label = @Translation("Entity Test without bundle"),
- *   base_table = "entity_test_no_bundle",
- *   handlers = {
- *     "views_data" = "Drupal\views\EntityViewsData"
- *   },
- *   entity_keys = {
- *     "id" = "id",
- *     "revision" = "revision_id",
- *   },
- *   admin_permission = "administer entity_test content",
- *   links = {
- *     "add-form" = "/entity_test_no_bundle/add",
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_no_bundle', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Entity Test without bundle'), base_table: 'entity_test_no_bundle', handlers: ['views_data' => 'Drupal\views\EntityViewsData'], entity_keys: ['id' => 'id', 'revision' => 'revision_id'], admin_permission: 'administer entity_test content', links: ['add-form' => '/entity_test_no_bundle/add'])]
 class EntityTestNoBundle extends EntityTest {
 
 }

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestNoBundleWithLabel.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestNoBundleWithLabel.php
@@ -4,25 +4,8 @@ namespace Drupal\entity_test\Entity;
 
 /**
  * Test entity class with no bundle but with label.
- *
- * @ContentEntityType(
- *   id = "entity_test_no_bundle_with_label",
- *   label = @Translation("Entity Test without bundle but with label"),
- *   base_table = "entity_test_no_bundle_with_label",
- *   handlers = {
- *     "views_data" = "Drupal\views\EntityViewsData"
- *   },
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "name",
- *     "revision" = "revision_id",
- *   },
- *   admin_permission = "administer entity_test content",
- *   links = {
- *     "add-form" = "/entity_test_no_bundle_with_label/add",
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_no_bundle_with_label', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Entity Test without bundle but with label'), base_table: 'entity_test_no_bundle_with_label', handlers: ['views_data' => 'Drupal\views\EntityViewsData'], entity_keys: ['id' => 'id', 'label' => 'name', 'revision' => 'revision_id'], admin_permission: 'administer entity_test content', links: ['add-form' => '/entity_test_no_bundle_with_label/add'])]
 class EntityTestNoBundleWithLabel extends EntityTest {
 
 }

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestNoId.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestNoId.php
@@ -4,23 +4,8 @@ namespace Drupal\entity_test\Entity;
 
 /**
  * Test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_no_id",
- *   label = @Translation("Entity Test without id"),
- *   handlers = {
- *     "storage" = "Drupal\Core\Entity\ContentEntityNullStorage",
- *   },
- *   entity_keys = {
- *     "bundle" = "type",
- *   },
- *   admin_permission = "administer entity_test content",
- *   field_ui_base_route = "entity.entity_test_no_id.admin_form",
- *   links = {
- *     "add-form" = "/entity_test_no_id/add",
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_no_id', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Entity Test without id'), handlers: ['storage' => 'Drupal\Core\Entity\ContentEntityNullStorage'], entity_keys: ['bundle' => 'type'], admin_permission: 'administer entity_test content', field_ui_base_route: 'entity.entity_test_no_id.admin_form', links: ['add-form' => '/entity_test_no_id/add'])]
 class EntityTestNoId extends EntityTest {
 
 }

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestNoLabel.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestNoLabel.php
@@ -4,23 +4,8 @@ namespace Drupal\entity_test\Entity;
 
 /**
  * Test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_no_label",
- *   label = @Translation("Entity Test without label"),
- *   internal = TRUE,
- *   persistent_cache = FALSE,
- *   base_table = "entity_test_no_label",
- *   handlers = {
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *   },
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_no_label', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Entity Test without label'), internal: true, persistent_cache: false, base_table: 'entity_test_no_label', handlers: ['access' => 'Drupal\entity_test\EntityTestAccessControlHandler'], entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type'])]
 class EntityTestNoLabel extends EntityTest {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestNoUuid.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestNoUuid.php
@@ -4,26 +4,8 @@ namespace Drupal\entity_test\Entity;
 
 /**
  * Test entity class with revisions but without UUIDs.
- *
- * @ContentEntityType(
- *   id = "entity_test_no_uuid",
- *   label = @Translation("Test entity without UUID"),
- *   handlers = {
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *   },
- *   base_table = "entity_test_no_uuid",
- *   revision_table = "entity_test_no_uuid_revision",
- *   admin_permission = "administer entity_test content",
- *   persistent_cache = FALSE,
- *   entity_keys = {
- *     "id" = "id",
- *     "revision" = "vid",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_no_uuid', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity without UUID'), handlers: ['access' => 'Drupal\entity_test\EntityTestAccessControlHandler'], base_table: 'entity_test_no_uuid', revision_table: 'entity_test_no_uuid_revision', admin_permission: 'administer entity_test content', persistent_cache: false, entity_keys: ['id' => 'id', 'revision' => 'vid', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'])]
 class EntityTestNoUuid extends EntityTest {
 
 }

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestRev.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestRev.php
@@ -7,51 +7,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_rev",
- *   label = @Translation("Test entity - revisions"),
- *   handlers = {
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilder",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm",
- *       "delete" = "Drupal\entity_test\EntityTestDeleteForm",
- *       "delete-multiple-confirm" = \Drupal\Core\Entity\Form\DeleteMultipleForm::class,
- *       "revision-delete" = \Drupal\Core\Entity\Form\RevisionDeleteForm::class,
- *       "revision-revert" = \Drupal\Core\Entity\Form\RevisionRevertForm::class,
- *     },
- *     "views_data" = "Drupal\views\EntityViewsData",
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *       "revision" = \Drupal\Core\Entity\Routing\RevisionHtmlRouteProvider::class,
- *     },
- *   },
- *   base_table = "entity_test_rev",
- *   revision_table = "entity_test_rev_revision",
- *   admin_permission = "administer entity_test content",
- *   show_revision_ui = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "revision" = "revision_id",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- *   links = {
- *     "add-form" = "/entity_test_rev/add",
- *     "canonical" = "/entity_test_rev/manage/{entity_test_rev}",
- *     "delete-form" = "/entity_test/delete/entity_test_rev/{entity_test_rev}",
- *     "delete-multiple-form" = "/entity_test_rev/delete_multiple",
- *     "edit-form" = "/entity_test_rev/manage/{entity_test_rev}/edit",
- *     "revision" = "/entity_test_rev/{entity_test_rev}/revision/{entity_test_rev_revision}/view",
- *     "revision-delete-form" = "/entity_test_rev/{entity_test_rev}/revision/{entity_test_rev_revision}/delete",
- *     "revision-revert-form" = "/entity_test_rev/{entity_test_rev}/revision/{entity_test_rev_revision}/revert",
- *     "version-history" = "/entity_test_rev/{entity_test_rev}/revisions",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_rev', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - revisions'), handlers: ['access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'view_builder' => 'Drupal\entity_test\EntityTestViewBuilder', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm', 'delete' => 'Drupal\entity_test\EntityTestDeleteForm', 'delete-multiple-confirm' => \Drupal\Core\Entity\Form\DeleteMultipleForm::class, 'revision-delete' => \Drupal\Core\Entity\Form\RevisionDeleteForm::class, 'revision-revert' => \Drupal\Core\Entity\Form\RevisionRevertForm::class], 'views_data' => 'Drupal\views\EntityViewsData', 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider', 'revision' => \Drupal\Core\Entity\Routing\RevisionHtmlRouteProvider::class]], base_table: 'entity_test_rev', revision_table: 'entity_test_rev_revision', admin_permission: 'administer entity_test content', show_revision_ui: true, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'revision' => 'revision_id', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'], links: ['add-form' => '/entity_test_rev/add', 'canonical' => '/entity_test_rev/manage/{entity_test_rev}', 'delete-form' => '/entity_test/delete/entity_test_rev/{entity_test_rev}', 'delete-multiple-form' => '/entity_test_rev/delete_multiple', 'edit-form' => '/entity_test_rev/manage/{entity_test_rev}/edit', 'revision' => '/entity_test_rev/{entity_test_rev}/revision/{entity_test_rev_revision}/view', 'revision-delete-form' => '/entity_test_rev/{entity_test_rev}/revision/{entity_test_rev_revision}/delete', 'revision-revert-form' => '/entity_test_rev/{entity_test_rev}/revision/{entity_test_rev_revision}/revert', 'version-history' => '/entity_test_rev/{entity_test_rev}/revisions'])]
 class EntityTestRev extends EntityTest {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestRevPub.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestRevPub.php
@@ -8,51 +8,8 @@ use Drupal\Core\Entity\EntityTypeInterface;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_revpub",
- *   label = @Translation("Test entity - revisions and publishing status"),
- *   handlers = {
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilder",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm",
- *       "delete" = "Drupal\entity_test\EntityTestDeleteForm",
- *       "delete-multiple-confirm" = \Drupal\Core\Entity\Form\DeleteMultipleForm::class,
- *       "revision-delete" = \Drupal\Core\Entity\Form\RevisionDeleteForm::class,
- *       "revision-revert" = \Drupal\Core\Entity\Form\RevisionRevertForm::class,
- *     },
- *     "route_provider" = {
- *       "html" = \Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider::class,
- *       "revision" = \Drupal\Core\Entity\Routing\RevisionHtmlRouteProvider::class,
- *     },
- *   },
- *   base_table = "entity_test_revpub",
- *   revision_table = "entity_test_revpub_revision",
- *   admin_permission = "administer entity_test content",
- *   show_revision_ui = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "revision" = "revision_id",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *     "published" = "status",
- *   },
- *   links = {
- *     "add-form" = "/entity_test_revpub/add",
- *     "canonical" = "/entity_test_revpub/manage/{entity_test_revpub}",
- *     "delete-form" = "/entity_test/delete/entity_test_revpub/{entity_test_revpub}",
- *     "delete-multiple-form" = "/entity_test_revpub/delete_multiple",
- *     "edit-form" = "/entity_test_revpub/manage/{entity_test_revpub}/edit",
- *     "revision" = "/entity_test_revpub/{entity_test_revpub}/revision/{entity_test_revpub_revision}/view",
- *     "revision-delete-form" = "/entity_test_revpub/{entity_test_revpub}/revision/{entity_test_revpub_revision}/delete",
- *     "revision-revert-form" = "/entity_test_revpub/{entity_test_revpub}/revision/{entity_test_revpub_revision}/revert",
- *     "version-history" = "/entity_test_revpub/{entity_test_revpub}/revisions",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_revpub', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - revisions and publishing status'), handlers: ['access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'view_builder' => 'Drupal\entity_test\EntityTestViewBuilder', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm', 'delete' => 'Drupal\entity_test\EntityTestDeleteForm', 'delete-multiple-confirm' => \Drupal\Core\Entity\Form\DeleteMultipleForm::class, 'revision-delete' => \Drupal\Core\Entity\Form\RevisionDeleteForm::class, 'revision-revert' => \Drupal\Core\Entity\Form\RevisionRevertForm::class], 'route_provider' => ['html' => \Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider::class, 'revision' => \Drupal\Core\Entity\Routing\RevisionHtmlRouteProvider::class]], base_table: 'entity_test_revpub', revision_table: 'entity_test_revpub_revision', admin_permission: 'administer entity_test content', show_revision_ui: true, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'revision' => 'revision_id', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode', 'published' => 'status'], links: ['add-form' => '/entity_test_revpub/add', 'canonical' => '/entity_test_revpub/manage/{entity_test_revpub}', 'delete-form' => '/entity_test/delete/entity_test_revpub/{entity_test_revpub}', 'delete-multiple-form' => '/entity_test_revpub/delete_multiple', 'edit-form' => '/entity_test_revpub/manage/{entity_test_revpub}/edit', 'revision' => '/entity_test_revpub/{entity_test_revpub}/revision/{entity_test_revpub_revision}/view', 'revision-delete-form' => '/entity_test_revpub/{entity_test_revpub}/revision/{entity_test_revpub_revision}/delete', 'revision-revert-form' => '/entity_test_revpub/{entity_test_revpub}/revision/{entity_test_revpub_revision}/revert', 'version-history' => '/entity_test_revpub/{entity_test_revpub}/revisions'])]
 class EntityTestRevPub extends EntityTestRev implements EntityPublishedInterface {
 
   use EntityPublishedTrait;

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestStringId.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestStringId.php
@@ -7,35 +7,8 @@ use Drupal\Core\Entity\EntityTypeInterface;
 
 /**
  * Defines a test entity class with a string ID.
- *
- * @ContentEntityType(
- *   id = "entity_test_string_id",
- *   label = @Translation("Test entity with string_id"),
- *   handlers = {
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\entity_test\EntityTestForm"
- *     },
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *   },
- *   base_table = "entity_test_string",
- *   admin_permission = "administer entity_test content",
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *   },
- *   links = {
- *     "canonical" = "/entity_test_string_id/manage/{entity_test_string_id}",
- *     "add-form" = "/entity_test_string_id/add",
- *     "edit-form" = "/entity_test_string_id/manage/{entity_test_string_id}",
- *   },
- *   field_ui_base_route = "entity.entity_test_string_id.admin_form",
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_string_id', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity with string_id'), handlers: ['access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'form' => ['default' => 'Drupal\entity_test\EntityTestForm'], 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider']], base_table: 'entity_test_string', admin_permission: 'administer entity_test content', entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name'], links: ['canonical' => '/entity_test_string_id/manage/{entity_test_string_id}', 'add-form' => '/entity_test_string_id/add', 'edit-form' => '/entity_test_string_id/manage/{entity_test_string_id}'], field_ui_base_route: 'entity.entity_test_string_id.admin_form')]
 class EntityTestStringId extends EntityTest {
 
   /**

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestViewBuilder.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestViewBuilder.php
@@ -4,25 +4,8 @@ namespace Drupal\entity_test\Entity;
 
 /**
  * Test entity class for testing a view builder.
- *
- * @ContentEntityType(
- *   id = "entity_test_view_builder",
- *   label = @Translation("Entity Test view builder"),
- *   handlers = {
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilderOverriddenView",
- *   },
- *   base_table = "entity_test_view_builder",
- *   render_cache = FALSE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "label" = "name",
- *     "bundle" = "type",
- *     "langcode" = "langcode",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_view_builder', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Entity Test view builder'), handlers: ['access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'view_builder' => 'Drupal\entity_test\EntityTestViewBuilderOverriddenView'], base_table: 'entity_test_view_builder', render_cache: false, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'name', 'bundle' => 'type', 'langcode' => 'langcode'])]
 class EntityTestViewBuilder extends EntityTest {
 
 }

--- a/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestWithBundle.php
+++ b/core/modules/system/tests/modules/entity_test/src/Entity/EntityTestWithBundle.php
@@ -8,45 +8,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Defines the Test entity with bundle entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_with_bundle",
- *   label = @Translation("Test entity with bundle"),
- *   handlers = {
- *     "list_builder" = "Drupal\entity_test\EntityTestListBuilder",
- *     "view_builder" = "Drupal\entity_test\EntityTestViewBuilder",
- *     "access" = "Drupal\entity_test\EntityTestAccessControlHandler",
- *     "form" = {
- *       "default" = "\Drupal\Core\Entity\ContentEntityForm",
- *       "delete" = "\Drupal\Core\Entity\EntityDeleteForm"
- *     },
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider",
- *     },
- *   },
- *   base_table = "entity_test_with_bundle",
- *   data_table = "entity_test_with_bundle_field_data",
- *   admin_permission = "administer entity_test_with_bundle content",
- *   persistent_cache = FALSE,
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- *   bundle_entity_type = "entity_test_bundle",
- *   links = {
- *     "canonical" = "/entity_test_with_bundle/{entity_test_with_bundle}",
- *     "add-page" = "/entity_test_with_bundle/add",
- *     "add-form" = "/entity_test_with_bundle/add/{entity_test_bundle}",
- *     "edit-form" = "/entity_test_with_bundle/{entity_test_with_bundle}/edit",
- *     "delete-form" = "/entity_test_with_bundle/{entity_test_with_bundle}/delete",
- *     "create" = "/entity_test_with_bundle",
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_with_bundle', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity with bundle'), handlers: ['list_builder' => 'Drupal\entity_test\EntityTestListBuilder', 'view_builder' => 'Drupal\entity_test\EntityTestViewBuilder', 'access' => 'Drupal\entity_test\EntityTestAccessControlHandler', 'form' => ['default' => '\Drupal\Core\Entity\ContentEntityForm', 'delete' => '\Drupal\Core\Entity\EntityDeleteForm'], 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider']], base_table: 'entity_test_with_bundle', data_table: 'entity_test_with_bundle_field_data', admin_permission: 'administer entity_test_with_bundle content', persistent_cache: false, translatable: true, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'], bundle_entity_type: 'entity_test_bundle', links: ['canonical' => '/entity_test_with_bundle/{entity_test_with_bundle}', 'add-page' => '/entity_test_with_bundle/add', 'add-form' => '/entity_test_with_bundle/add/{entity_test_bundle}', 'edit-form' => '/entity_test_with_bundle/{entity_test_with_bundle}/edit', 'delete-form' => '/entity_test_with_bundle/{entity_test_with_bundle}/delete', 'create' => '/entity_test_with_bundle'])]
 class EntityTestWithBundle extends ContentEntityBase {
 
   /**

--- a/core/modules/system/tests/modules/entity_test_revlog/src/Entity/EntityTestMulWithRevisionLog.php
+++ b/core/modules/system/tests/modules/entity_test_revlog/src/Entity/EntityTestMulWithRevisionLog.php
@@ -4,52 +4,8 @@ namespace Drupal\entity_test_revlog\Entity;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_mul_revlog",
- *   label = @Translation("Test entity - data table, revisions log"),
- *   handlers = {
- *     "access" = \Drupal\entity_test_revlog\EntityTestRevlogAccessControlHandler::class,
- *     "form" = {
- *       "default" = \Drupal\Core\Entity\ContentEntityForm::class,
- *       "revision-delete" = \Drupal\Core\Entity\Form\RevisionDeleteForm::class,
- *       "revision-revert" = \Drupal\Core\Entity\Form\RevisionRevertForm::class,
- *     },
- *     "route_provider" = {
- *       "html" = \Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider::class,
- *       "revision" = \Drupal\Core\Entity\Routing\RevisionHtmlRouteProvider::class,
- *     },
- *   },
- *   base_table = "entity_test_mul_revlog",
- *   data_table = "entity_test_mul_revlog_field_data",
- *   revision_table = "entity_test_mul_revlog_revision",
- *   revision_data_table = "entity_test_mul_revlog_field_revision",
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "revision" = "revision_id",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- *   revision_metadata_keys = {
- *     "revision_user" = "revision_user",
- *     "revision_created" = "revision_created",
- *     "revision_log_message" = "revision_log_message"
- *   },
- *   links = {
- *     "add-form" = "/entity_test_mul_revlog/add",
- *     "canonical" = "/entity_test_mul_revlog/manage/{entity_test_mul_revlog}",
- *     "delete-form" = "/entity_test/delete/entity_test_mul_revlog/{entity_test_mul_revlog}",
- *     "edit-form" = "/entity_test_mul_revlog/manage/{entity_test_mul_revlog}/edit",
- *     "revision" = "/entity_test_mul_revlog/{entity_test_mul_revlog}/revision/{entity_test_mul_revlog_revision}/view",
- *     "revision-delete-form" = "/entity_test_mul_revlog/{entity_test_mul_revlog}/revision/{entity_test_mul_revlog_revision}/delete",
- *     "revision-revert-form" = "/entity_test_mul_revlog/{entity_test_mul_revlog}/revision/{entity_test_mul_revlog_revision}/revert",
- *     "version-history" = "/entity_test_mul_revlog/{entity_test_mul_revlog}/revisions",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_mul_revlog', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - data table, revisions log'), handlers: ['access' => \Drupal\entity_test_revlog\EntityTestRevlogAccessControlHandler::class, 'form' => ['default' => \Drupal\Core\Entity\ContentEntityForm::class, 'revision-delete' => \Drupal\Core\Entity\Form\RevisionDeleteForm::class, 'revision-revert' => \Drupal\Core\Entity\Form\RevisionRevertForm::class], 'route_provider' => ['html' => \Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider::class, 'revision' => \Drupal\Core\Entity\Routing\RevisionHtmlRouteProvider::class]], base_table: 'entity_test_mul_revlog', data_table: 'entity_test_mul_revlog_field_data', revision_table: 'entity_test_mul_revlog_revision', revision_data_table: 'entity_test_mul_revlog_field_revision', translatable: true, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'revision' => 'revision_id', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'], revision_metadata_keys: ['revision_user' => 'revision_user', 'revision_created' => 'revision_created', 'revision_log_message' => 'revision_log_message'], links: ['add-form' => '/entity_test_mul_revlog/add', 'canonical' => '/entity_test_mul_revlog/manage/{entity_test_mul_revlog}', 'delete-form' => '/entity_test/delete/entity_test_mul_revlog/{entity_test_mul_revlog}', 'edit-form' => '/entity_test_mul_revlog/manage/{entity_test_mul_revlog}/edit', 'revision' => '/entity_test_mul_revlog/{entity_test_mul_revlog}/revision/{entity_test_mul_revlog_revision}/view', 'revision-delete-form' => '/entity_test_mul_revlog/{entity_test_mul_revlog}/revision/{entity_test_mul_revlog_revision}/delete', 'revision-revert-form' => '/entity_test_mul_revlog/{entity_test_mul_revlog}/revision/{entity_test_mul_revlog_revision}/revert', 'version-history' => '/entity_test_mul_revlog/{entity_test_mul_revlog}/revisions'])]
 class EntityTestMulWithRevisionLog extends EntityTestWithRevisionLog {
 
 }

--- a/core/modules/system/tests/modules/entity_test_revlog/src/Entity/EntityTestMulWithRevisionLogPub.php
+++ b/core/modules/system/tests/modules/entity_test_revlog/src/Entity/EntityTestMulWithRevisionLogPub.php
@@ -8,31 +8,8 @@ use Drupal\Core\Entity\EntityTypeInterface;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_mul_revlog_pub",
- *   label = @Translation("Test entity - data table, revisions log, publishing status"),
- *   base_table = "entity_test_mul_revlog_pub",
- *   data_table = "entity_test_mul_revlog_pub_field_data",
- *   revision_table = "entity_test_mul_revlog_pub_revision",
- *   revision_data_table = "entity_test_mul_revlog_pub_field_revision",
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "revision" = "revision_id",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *     "published" = "status",
- *   },
- *   revision_metadata_keys = {
- *     "revision_user" = "revision_user",
- *     "revision_created" = "revision_created",
- *     "revision_log_message" = "revision_log_message"
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_mul_revlog_pub', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - data table, revisions log, publishing status'), base_table: 'entity_test_mul_revlog_pub', data_table: 'entity_test_mul_revlog_pub_field_data', revision_table: 'entity_test_mul_revlog_pub_revision', revision_data_table: 'entity_test_mul_revlog_pub_field_revision', translatable: true, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'revision' => 'revision_id', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode', 'published' => 'status'], revision_metadata_keys: ['revision_user' => 'revision_user', 'revision_created' => 'revision_created', 'revision_log_message' => 'revision_log_message'])]
 class EntityTestMulWithRevisionLogPub extends EntityTestWithRevisionLog implements EntityPublishedInterface {
 
   use EntityPublishedTrait;

--- a/core/modules/system/tests/modules/entity_test_revlog/src/Entity/EntityTestWithRevisionLog.php
+++ b/core/modules/system/tests/modules/entity_test_revlog/src/Entity/EntityTestWithRevisionLog.php
@@ -8,50 +8,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Defines the test entity class.
- *
- * @ContentEntityType(
- *   id = "entity_test_revlog",
- *   label = @Translation("Test entity - revisions log"),
- *   handlers = {
- *     "access" = "Drupal\entity_test_revlog\EntityTestRevlogAccessControlHandler",
- *     "form" = {
- *       "default" = \Drupal\Core\Entity\ContentEntityForm::class,
- *       "revision-delete" = \Drupal\Core\Entity\Form\RevisionDeleteForm::class,
- *       "revision-revert" = \Drupal\Core\Entity\Form\RevisionRevertForm::class,
- *     },
- *     "route_provider" = {
- *       "html" = \Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider::class,
- *       "revision" = \Drupal\Core\Entity\Routing\RevisionHtmlRouteProvider::class,
- *     },
- *   },
- *   base_table = "entity_test_revlog",
- *   revision_table = "entity_test_revlog_revision",
- *   translatable = FALSE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "revision" = "revision_id",
- *     "bundle" = "type",
- *     "label" = "name",
- *   },
- *   revision_metadata_keys = {
- *     "revision_user" = "revision_user",
- *     "revision_created" = "revision_created",
- *     "revision_log_message" = "revision_log_message"
- *   },
- *   links = {
- *     "add-form" = "/entity_test_revlog/add",
- *     "canonical" = "/entity_test_revlog/manage/{entity_test_revlog}",
- *     "delete-form" = "/entity_test/delete/entity_test_revlog/{entity_test_revlog}",
- *     "delete-multiple-form" = "/entity_test_revlog/delete_multiple",
- *     "edit-form" = "/entity_test_revlog/manage/{entity_test_revlog}/edit",
- *     "revision" = "/entity_test_revlog/{entity_test_revlog}/revision/{entity_test_revlog_revision}/view",
- *     "revision-delete-form" = "/entity_test_revlog/{entity_test_revlog}/revision/{entity_test_revlog_revision}/delete",
- *     "revision-revert-form" = "/entity_test_revlog/{entity_test_revlog}/revision/{entity_test_revlog_revision}/revert",
- *     "version-history" = "/entity_test_revlog/{entity_test_revlog}/revisions",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_revlog', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity - revisions log'), handlers: ['access' => 'Drupal\entity_test_revlog\EntityTestRevlogAccessControlHandler', 'form' => ['default' => \Drupal\Core\Entity\ContentEntityForm::class, 'revision-delete' => \Drupal\Core\Entity\Form\RevisionDeleteForm::class, 'revision-revert' => \Drupal\Core\Entity\Form\RevisionRevertForm::class], 'route_provider' => ['html' => \Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider::class, 'revision' => \Drupal\Core\Entity\Routing\RevisionHtmlRouteProvider::class]], base_table: 'entity_test_revlog', revision_table: 'entity_test_revlog_revision', translatable: false, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'revision' => 'revision_id', 'bundle' => 'type', 'label' => 'name'], revision_metadata_keys: ['revision_user' => 'revision_user', 'revision_created' => 'revision_created', 'revision_log_message' => 'revision_log_message'], links: ['add-form' => '/entity_test_revlog/add', 'canonical' => '/entity_test_revlog/manage/{entity_test_revlog}', 'delete-form' => '/entity_test/delete/entity_test_revlog/{entity_test_revlog}', 'delete-multiple-form' => '/entity_test_revlog/delete_multiple', 'edit-form' => '/entity_test_revlog/manage/{entity_test_revlog}/edit', 'revision' => '/entity_test_revlog/{entity_test_revlog}/revision/{entity_test_revlog_revision}/view', 'revision-delete-form' => '/entity_test_revlog/{entity_test_revlog}/revision/{entity_test_revlog_revision}/delete', 'revision-revert-form' => '/entity_test_revlog/{entity_test_revlog}/revision/{entity_test_revlog_revision}/revert', 'version-history' => '/entity_test_revlog/{entity_test_revlog}/revisions'])]
 class EntityTestWithRevisionLog extends RevisionableContentEntityBase {
 
   /**

--- a/core/modules/system/tests/modules/entity_test_update/src/Entity/EntityTestUpdate.php
+++ b/core/modules/system/tests/modules/entity_test_update/src/Entity/EntityTestUpdate.php
@@ -15,26 +15,8 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  * an update test it can be made revisionable and translatable using the helper
  * methods from
  * \Drupal\Tests\system\Functional\Entity\Traits\EntityDefinitionTestTrait.
- *
- * @ContentEntityType(
- *   id = "entity_test_update",
- *   label = @Translation("Test entity update"),
- *   handlers = {
- *     "storage_schema" = "Drupal\entity_test_update\EntityTestUpdateStorageSchema",
- *     "storage" = "Drupal\entity_test_update\EntityTestUpdateStorage",
- *   },
- *   base_table = "entity_test_update",
- *   persistent_cache = FALSE,
- *   entity_keys = {
- *     "id" = "id",
- *     "uuid" = "uuid",
- *     "bundle" = "type",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *   },
- *   content_translation_ui_skip = TRUE,
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'entity_test_update', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity update'), handlers: ['storage_schema' => 'Drupal\entity_test_update\EntityTestUpdateStorageSchema', 'storage' => 'Drupal\entity_test_update\EntityTestUpdateStorage'], base_table: 'entity_test_update', persistent_cache: false, entity_keys: ['id' => 'id', 'uuid' => 'uuid', 'bundle' => 'type', 'label' => 'name', 'langcode' => 'langcode'], content_translation_ui_skip: true)]
 class EntityTestUpdate extends ContentEntityBase {
 
   /**

--- a/core/modules/system/tests/modules/module_installer_config_test/src/Entity/TestConfigType.php
+++ b/core/modules/system/tests/modules/module_installer_config_test/src/Entity/TestConfigType.php
@@ -6,24 +6,7 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
 
 /**
  * Defines a configuration-based entity type used for testing.
- *
- * @ConfigEntityType(
- *   id = "test_config_type",
- *   label = @Translation("Test entity type"),
- *   handlers = {
- *     "list_builder" = "Drupal\Core\Entity\EntityListBuilder"
- *   },
- *   admin_permission = "administer modules",
- *   config_prefix = "type",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "name"
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'test_config_type', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test entity type'), handlers: ['list_builder' => 'Drupal\Core\Entity\EntityListBuilder'], admin_permission: 'administer modules', config_prefix: 'type', entity_keys: ['id' => 'id', 'label' => 'name'], config_export: ['id', 'label'])]
 class TestConfigType extends ConfigEntityBase {
 }

--- a/core/modules/taxonomy/src/Entity/Term.php
+++ b/core/modules/taxonomy/src/Entity/Term.php
@@ -11,65 +11,8 @@ use Drupal\user\StatusItem;
 
 /**
  * Defines the taxonomy term entity.
- *
- * @ContentEntityType(
- *   id = "taxonomy_term",
- *   label = @Translation("Taxonomy term"),
- *   label_collection = @Translation("Taxonomy terms"),
- *   label_singular = @Translation("taxonomy term"),
- *   label_plural = @Translation("taxonomy terms"),
- *   label_count = @PluralTranslation(
- *     singular = "@count taxonomy term",
- *     plural = "@count taxonomy terms",
- *   ),
- *   bundle_label = @Translation("Vocabulary"),
- *   handlers = {
- *     "storage" = "Drupal\taxonomy\TermStorage",
- *     "storage_schema" = "Drupal\taxonomy\TermStorageSchema",
- *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
- *     "list_builder" = "Drupal\Core\Entity\EntityListBuilder",
- *     "access" = "Drupal\taxonomy\TermAccessControlHandler",
- *     "views_data" = "Drupal\taxonomy\TermViewsData",
- *     "form" = {
- *       "default" = "Drupal\taxonomy\TermForm",
- *       "delete" = "Drupal\taxonomy\Form\TermDeleteForm"
- *     },
- *     "translation" = "Drupal\taxonomy\TermTranslationHandler"
- *   },
- *   base_table = "taxonomy_term_data",
- *   data_table = "taxonomy_term_field_data",
- *   revision_table = "taxonomy_term_revision",
- *   revision_data_table = "taxonomy_term_field_revision",
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "tid",
- *     "revision" = "revision_id",
- *     "bundle" = "vid",
- *     "label" = "name",
- *     "langcode" = "langcode",
- *     "uuid" = "uuid",
- *     "published" = "status",
- *   },
- *   revision_metadata_keys = {
- *     "revision_user" = "revision_user",
- *     "revision_created" = "revision_created",
- *     "revision_log_message" = "revision_log_message",
- *   },
- *   bundle_entity_type = "taxonomy_vocabulary",
- *   field_ui_base_route = "entity.taxonomy_vocabulary.overview_form",
- *   common_reference_target = TRUE,
- *   links = {
- *     "canonical" = "/taxonomy/term/{taxonomy_term}",
- *     "delete-form" = "/taxonomy/term/{taxonomy_term}/delete",
- *     "edit-form" = "/taxonomy/term/{taxonomy_term}/edit",
- *     "create" = "/taxonomy/term",
- *   },
- *   permission_granularity = "bundle",
- *   constraints = {
- *     "TaxonomyHierarchy" = {}
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'taxonomy_term', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Taxonomy term'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Taxonomy terms'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('taxonomy term'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('taxonomy terms'), label_count: ['singular' => '@count taxonomy term', 'plural' => '@count taxonomy terms'], bundle_label: new Drupal\Core\StringTranslation\TranslatableMarkup('Vocabulary'), handlers: ['storage' => 'Drupal\taxonomy\TermStorage', 'storage_schema' => 'Drupal\taxonomy\TermStorageSchema', 'view_builder' => 'Drupal\Core\Entity\EntityViewBuilder', 'list_builder' => 'Drupal\Core\Entity\EntityListBuilder', 'access' => 'Drupal\taxonomy\TermAccessControlHandler', 'views_data' => 'Drupal\taxonomy\TermViewsData', 'form' => ['default' => 'Drupal\taxonomy\TermForm', 'delete' => 'Drupal\taxonomy\Form\TermDeleteForm'], 'translation' => 'Drupal\taxonomy\TermTranslationHandler'], base_table: 'taxonomy_term_data', data_table: 'taxonomy_term_field_data', revision_table: 'taxonomy_term_revision', revision_data_table: 'taxonomy_term_field_revision', translatable: true, entity_keys: ['id' => 'tid', 'revision' => 'revision_id', 'bundle' => 'vid', 'label' => 'name', 'langcode' => 'langcode', 'uuid' => 'uuid', 'published' => 'status'], revision_metadata_keys: ['revision_user' => 'revision_user', 'revision_created' => 'revision_created', 'revision_log_message' => 'revision_log_message'], bundle_entity_type: 'taxonomy_vocabulary', field_ui_base_route: 'entity.taxonomy_vocabulary.overview_form', common_reference_target: true, links: ['canonical' => '/taxonomy/term/{taxonomy_term}', 'delete-form' => '/taxonomy/term/{taxonomy_term}/delete', 'edit-form' => '/taxonomy/term/{taxonomy_term}/edit', 'create' => '/taxonomy/term'], permission_granularity: 'bundle', constraints: ['TaxonomyHierarchy' => []])]
 class Term extends EditorialContentEntityBase implements TermInterface {
 
   /**

--- a/core/modules/taxonomy/src/Entity/Vocabulary.php
+++ b/core/modules/taxonomy/src/Entity/Vocabulary.php
@@ -8,57 +8,8 @@ use Drupal\taxonomy\VocabularyInterface;
 
 /**
  * Defines the taxonomy vocabulary entity.
- *
- * @ConfigEntityType(
- *   id = "taxonomy_vocabulary",
- *   label = @Translation("Taxonomy vocabulary"),
- *   label_singular = @Translation("vocabulary"),
- *   label_plural = @Translation("vocabularies"),
- *   label_collection = @Translation("Taxonomy"),
- *   label_count = @PluralTranslation(
- *     singular = "@count vocabulary",
- *     plural = "@count vocabularies"
- *   ),
- *   handlers = {
- *     "storage" = "Drupal\taxonomy\VocabularyStorage",
- *     "list_builder" = "Drupal\taxonomy\VocabularyListBuilder",
- *     "access" = "Drupal\taxonomy\VocabularyAccessControlHandler",
- *     "form" = {
- *       "default" = "Drupal\taxonomy\VocabularyForm",
- *       "reset" = "Drupal\taxonomy\Form\VocabularyResetForm",
- *       "delete" = "Drupal\taxonomy\Form\VocabularyDeleteForm",
- *       "overview" = "Drupal\taxonomy\Form\OverviewTerms"
- *     },
- *     "route_provider" = {
- *       "html" = "Drupal\taxonomy\Entity\Routing\VocabularyRouteProvider",
- *       "permissions" = "Drupal\user\Entity\EntityPermissionsRouteProvider",
- *     }
- *   },
- *   admin_permission = "administer taxonomy",
- *   config_prefix = "vocabulary",
- *   bundle_of = "taxonomy_term",
- *   entity_keys = {
- *     "id" = "vid",
- *     "label" = "name",
- *     "weight" = "weight"
- *   },
- *   links = {
- *     "add-form" = "/admin/structure/taxonomy/add",
- *     "delete-form" = "/admin/structure/taxonomy/manage/{taxonomy_vocabulary}/delete",
- *     "reset-form" = "/admin/structure/taxonomy/manage/{taxonomy_vocabulary}/reset",
- *     "overview-form" = "/admin/structure/taxonomy/manage/{taxonomy_vocabulary}/overview",
- *     "edit-form" = "/admin/structure/taxonomy/manage/{taxonomy_vocabulary}",
- *     "entity-permissions-form" = "/admin/structure/taxonomy/manage/{taxonomy_vocabulary}/overview/permissions",
- *     "collection" = "/admin/structure/taxonomy",
- *   },
- *   config_export = {
- *     "name",
- *     "vid",
- *     "description",
- *     "weight",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'taxonomy_vocabulary', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Taxonomy vocabulary'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('vocabulary'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('vocabularies'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Taxonomy'), label_count: ['singular' => '@count vocabulary', 'plural' => '@count vocabularies'], handlers: ['storage' => 'Drupal\taxonomy\VocabularyStorage', 'list_builder' => 'Drupal\taxonomy\VocabularyListBuilder', 'access' => 'Drupal\taxonomy\VocabularyAccessControlHandler', 'form' => ['default' => 'Drupal\taxonomy\VocabularyForm', 'reset' => 'Drupal\taxonomy\Form\VocabularyResetForm', 'delete' => 'Drupal\taxonomy\Form\VocabularyDeleteForm', 'overview' => 'Drupal\taxonomy\Form\OverviewTerms'], 'route_provider' => ['html' => 'Drupal\taxonomy\Entity\Routing\VocabularyRouteProvider', 'permissions' => 'Drupal\user\Entity\EntityPermissionsRouteProvider']], admin_permission: 'administer taxonomy', config_prefix: 'vocabulary', bundle_of: 'taxonomy_term', entity_keys: ['id' => 'vid', 'label' => 'name', 'weight' => 'weight'], links: ['add-form' => '/admin/structure/taxonomy/add', 'delete-form' => '/admin/structure/taxonomy/manage/{taxonomy_vocabulary}/delete', 'reset-form' => '/admin/structure/taxonomy/manage/{taxonomy_vocabulary}/reset', 'overview-form' => '/admin/structure/taxonomy/manage/{taxonomy_vocabulary}/overview', 'edit-form' => '/admin/structure/taxonomy/manage/{taxonomy_vocabulary}', 'entity-permissions-form' => '/admin/structure/taxonomy/manage/{taxonomy_vocabulary}/overview/permissions', 'collection' => '/admin/structure/taxonomy'], config_export: ['name', 'vid', 'description', 'weight'])]
 class Vocabulary extends ConfigEntityBundleBase implements VocabularyInterface {
 
   /**

--- a/core/modules/tour/src/Entity/Tour.php
+++ b/core/modules/tour/src/Entity/Tour.php
@@ -8,38 +8,8 @@ use Drupal\tour\TourInterface;
 
 /**
  * Defines the configured tour entity.
- *
- * @ConfigEntityType(
- *   id = "tour",
- *   label = @Translation("Tour"),
- *   label_collection = @Translation("Tours"),
- *   label_singular = @Translation("tour"),
- *   label_plural = @Translation("tours"),
- *   label_count = @PluralTranslation(
- *     singular = "@count tour",
- *     plural = "@count tours",
- *   ),
- *   handlers = {
- *     "view_builder" = "Drupal\tour\TourViewBuilder",
- *     "access" = "Drupal\tour\TourAccessControlHandler",
- *   },
- *   admin_permission = "administer site configuration",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label"
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "module",
- *     "routes",
- *     "tips",
- *   },
- *   lookup_keys = {
- *     "routes.*.route_name"
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'tour', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Tour'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Tours'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('tour'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('tours'), label_count: ['singular' => '@count tour', 'plural' => '@count tours'], handlers: ['view_builder' => 'Drupal\tour\TourViewBuilder', 'access' => 'Drupal\tour\TourAccessControlHandler'], admin_permission: 'administer site configuration', entity_keys: ['id' => 'id', 'label' => 'label'], config_export: ['id', 'label', 'module', 'routes', 'tips'], lookup_keys: ['routes.*.route_name'])]
 class Tour extends ConfigEntityBase implements TourInterface {
 
   /**

--- a/core/modules/user/src/Entity/Role.php
+++ b/core/modules/user/src/Entity/Role.php
@@ -8,49 +8,8 @@ use Drupal\user\RoleInterface;
 
 /**
  * Defines the user role entity class.
- *
- * @ConfigEntityType(
- *   id = "user_role",
- *   label = @Translation("Role"),
- *   label_collection = @Translation("Roles"),
- *   label_singular = @Translation("role"),
- *   label_plural = @Translation("roles"),
- *   label_count = @PluralTranslation(
- *     singular = "@count role",
- *     plural = "@count roles",
- *   ),
- *   handlers = {
- *     "storage" = "Drupal\user\RoleStorage",
- *     "access" = "Drupal\user\RoleAccessControlHandler",
- *     "list_builder" = "Drupal\user\RoleListBuilder",
- *     "form" = {
- *       "default" = "Drupal\user\RoleForm",
- *       "delete" = "Drupal\Core\Entity\EntityDeleteForm"
- *     }
- *   },
- *   admin_permission = "administer permissions",
- *   config_prefix = "role",
- *   static_cache = TRUE,
- *   entity_keys = {
- *     "id" = "id",
- *     "weight" = "weight",
- *     "label" = "label"
- *   },
- *   links = {
- *     "delete-form" = "/admin/people/roles/manage/{user_role}/delete",
- *     "edit-form" = "/admin/people/roles/manage/{user_role}",
- *     "edit-permissions-form" = "/admin/people/permissions/{user_role}",
- *     "collection" = "/admin/people/roles",
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "weight",
- *     "is_admin",
- *     "permissions",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'user_role', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Role'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Roles'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('role'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('roles'), label_count: ['singular' => '@count role', 'plural' => '@count roles'], handlers: ['storage' => 'Drupal\user\RoleStorage', 'access' => 'Drupal\user\RoleAccessControlHandler', 'list_builder' => 'Drupal\user\RoleListBuilder', 'form' => ['default' => 'Drupal\user\RoleForm', 'delete' => 'Drupal\Core\Entity\EntityDeleteForm']], admin_permission: 'administer permissions', config_prefix: 'role', static_cache: true, entity_keys: ['id' => 'id', 'weight' => 'weight', 'label' => 'label'], links: ['delete-form' => '/admin/people/roles/manage/{user_role}/delete', 'edit-form' => '/admin/people/roles/manage/{user_role}', 'edit-permissions-form' => '/admin/people/permissions/{user_role}', 'collection' => '/admin/people/roles'], config_export: ['id', 'label', 'weight', 'is_admin', 'permissions'])]
 class Role extends ConfigEntityBase implements RoleInterface {
 
   /**

--- a/core/modules/user/src/Entity/User.php
+++ b/core/modules/user/src/Entity/User.php
@@ -18,52 +18,8 @@ use Drupal\user\UserInterface;
  *
  * The base table name here is plural, despite Drupal table naming standards,
  * because "user" is a reserved word in many databases.
- *
- * @ContentEntityType(
- *   id = "user",
- *   label = @Translation("User"),
- *   label_collection = @Translation("Users"),
- *   label_singular = @Translation("user"),
- *   label_plural = @Translation("users"),
- *   label_count = @PluralTranslation(
- *     singular = "@count user",
- *     plural = "@count users",
- *   ),
- *   handlers = {
- *     "storage" = "Drupal\user\UserStorage",
- *     "storage_schema" = "Drupal\user\UserStorageSchema",
- *     "access" = "Drupal\user\UserAccessControlHandler",
- *     "list_builder" = "Drupal\user\UserListBuilder",
- *     "views_data" = "Drupal\user\UserViewsData",
- *     "route_provider" = {
- *       "html" = "Drupal\user\Entity\UserRouteProvider",
- *     },
- *     "form" = {
- *       "default" = "Drupal\user\ProfileForm",
- *       "cancel" = "Drupal\user\Form\UserCancelForm",
- *       "register" = "Drupal\user\RegisterForm"
- *     },
- *     "translation" = "Drupal\user\ProfileTranslationHandler"
- *   },
- *   admin_permission = "administer users",
- *   base_table = "users",
- *   data_table = "users_field_data",
- *   translatable = TRUE,
- *   entity_keys = {
- *     "id" = "uid",
- *     "langcode" = "langcode",
- *     "uuid" = "uuid"
- *   },
- *   links = {
- *     "canonical" = "/user/{user}",
- *     "edit-form" = "/user/{user}/edit",
- *     "cancel-form" = "/user/{user}/cancel",
- *     "collection" = "/admin/people",
- *   },
- *   field_ui_base_route = "entity.user.admin_form",
- *   common_reference_target = TRUE
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'user', label: new Drupal\Core\StringTranslation\TranslatableMarkup('User'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Users'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('user'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('users'), label_count: ['singular' => '@count user', 'plural' => '@count users'], handlers: ['storage' => 'Drupal\user\UserStorage', 'storage_schema' => 'Drupal\user\UserStorageSchema', 'access' => 'Drupal\user\UserAccessControlHandler', 'list_builder' => 'Drupal\user\UserListBuilder', 'views_data' => 'Drupal\user\UserViewsData', 'route_provider' => ['html' => 'Drupal\user\Entity\UserRouteProvider'], 'form' => ['default' => 'Drupal\user\ProfileForm', 'cancel' => 'Drupal\user\Form\UserCancelForm', 'register' => 'Drupal\user\RegisterForm'], 'translation' => 'Drupal\user\ProfileTranslationHandler'], admin_permission: 'administer users', base_table: 'users', data_table: 'users_field_data', translatable: true, entity_keys: ['id' => 'uid', 'langcode' => 'langcode', 'uuid' => 'uuid'], links: ['canonical' => '/user/{user}', 'edit-form' => '/user/{user}/edit', 'cancel-form' => '/user/{user}/cancel', 'collection' => '/admin/people'], field_ui_base_route: 'entity.user.admin_form', common_reference_target: true)]
 class User extends ContentEntityBase implements UserInterface {
 
   use EntityChangedTrait;

--- a/core/modules/views/src/Entity/View.php
+++ b/core/modules/views/src/Entity/View.php
@@ -13,36 +13,8 @@ use Drupal\views\ViewEntityInterface;
 
 /**
  * Defines a View configuration entity class.
- *
- * @ConfigEntityType(
- *   id = "view",
- *   label = @Translation("View", context = "View entity type"),
- *   label_collection = @Translation("Views", context = "View entity type"),
- *   label_singular = @Translation("view", context = "View entity type"),
- *   label_plural = @Translation("views", context = "View entity type"),
- *   label_count = @PluralTranslation(
- *     singular = "@count view",
- *     plural = "@count views",
- *     context = "View entity type",
- *   ),
- *   admin_permission = "administer views",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label",
- *     "status" = "status"
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "module",
- *     "description",
- *     "tag",
- *     "base_table",
- *     "base_field",
- *     "display",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'view', label: new Drupal\Core\StringTranslation\TranslatableMarkup('View', ['context' => 'View entity type']), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Views', ['context' => 'View entity type']), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('view', ['context' => 'View entity type']), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('views', ['context' => 'View entity type']), label_count: ['singular' => '@count view', 'plural' => '@count views'], admin_permission: 'administer views', entity_keys: ['id' => 'id', 'label' => 'label', 'status' => 'status'], config_export: ['id', 'label', 'module', 'description', 'tag', 'base_table', 'base_field', 'display'])]
 class View extends ConfigEntityBase implements ViewEntityInterface {
 
   /**

--- a/core/modules/views/tests/modules/views_config_entity_test/src/Entity/ViewsConfigEntityTest.php
+++ b/core/modules/views/tests/modules/views_config_entity_test/src/Entity/ViewsConfigEntityTest.php
@@ -6,25 +6,7 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
 
 /**
  * Defines a configuration-based entity type used for testing Views data.
- *
- * @ConfigEntityType(
- *   id = "views_config_entity_test",
- *   label = @Translation("Test config entity type with Views data"),
- *   handlers = {
- *     "list_builder" = "Drupal\Core\Entity\EntityListBuilder",
- *     "views_data" = "Drupal\views_config_entity_test\ViewsConfigEntityTestViewsData"
- *   },
- *   admin_permission = "administer modules",
- *   config_prefix = "type",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "name"
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *   }
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'views_config_entity_test', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Test config entity type with Views data'), handlers: ['list_builder' => 'Drupal\Core\Entity\EntityListBuilder', 'views_data' => 'Drupal\views_config_entity_test\ViewsConfigEntityTestViewsData'], admin_permission: 'administer modules', config_prefix: 'type', entity_keys: ['id' => 'id', 'label' => 'name'], config_export: ['id', 'label'])]
 class ViewsConfigEntityTest extends ConfigEntityBase {
 }

--- a/core/modules/workflows/src/Entity/Workflow.php
+++ b/core/modules/workflows/src/Entity/Workflow.php
@@ -11,58 +11,8 @@ use Drupal\workflows\WorkflowInterface;
 
 /**
  * Defines the workflow entity.
- *
- * @ConfigEntityType(
- *   id = "workflow",
- *   label = @Translation("Workflow"),
- *   label_collection = @Translation("Workflows"),
- *   label_singular = @Translation("workflow"),
- *   label_plural = @Translation("workflows"),
- *   label_count = @PluralTranslation(
- *     singular = "@count workflow",
- *     plural = "@count workflows",
- *   ),
- *   handlers = {
- *     "access" = "Drupal\workflows\WorkflowAccessControlHandler",
- *     "list_builder" = "Drupal\workflows\WorkflowListBuilder",
- *     "form" = {
- *       "add" = "Drupal\workflows\Form\WorkflowAddForm",
- *       "edit" = "Drupal\workflows\Form\WorkflowEditForm",
- *       "delete" = "Drupal\workflows\Form\WorkflowDeleteForm",
- *       "add-state" = "Drupal\workflows\Form\WorkflowStateAddForm",
- *       "edit-state" = "Drupal\workflows\Form\WorkflowStateEditForm",
- *       "delete-state" = "Drupal\workflows\Form\WorkflowStateDeleteForm",
- *       "add-transition" = "Drupal\workflows\Form\WorkflowTransitionAddForm",
- *       "edit-transition" = "Drupal\workflows\Form\WorkflowTransitionEditForm",
- *       "delete-transition" = "Drupal\workflows\Form\WorkflowTransitionDeleteForm",
- *     },
- *     "route_provider" = {
- *       "html" = "Drupal\Core\Entity\Routing\AdminHtmlRouteProvider",
- *     },
- *   },
- *   config_prefix = "workflow",
- *   admin_permission = "administer workflows",
- *   entity_keys = {
- *     "id" = "id",
- *     "label" = "label",
- *     "uuid" = "uuid",
- *   },
- *   links = {
- *     "add-form" = "/admin/config/workflow/workflows/add",
- *     "edit-form" = "/admin/config/workflow/workflows/manage/{workflow}",
- *     "delete-form" = "/admin/config/workflow/workflows/manage/{workflow}/delete",
- *     "add-state-form" = "/admin/config/workflow/workflows/manage/{workflow}/add_state",
- *     "add-transition-form" = "/admin/config/workflow/workflows/manage/{workflow}/add_transition",
- *     "collection" = "/admin/config/workflow/workflows",
- *   },
- *   config_export = {
- *     "id",
- *     "label",
- *     "type",
- *     "type_settings",
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ConfigEntityType(id: 'workflow', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Workflow'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Workflows'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('workflow'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('workflows'), label_count: ['singular' => '@count workflow', 'plural' => '@count workflows'], handlers: ['access' => 'Drupal\workflows\WorkflowAccessControlHandler', 'list_builder' => 'Drupal\workflows\WorkflowListBuilder', 'form' => ['add' => 'Drupal\workflows\Form\WorkflowAddForm', 'edit' => 'Drupal\workflows\Form\WorkflowEditForm', 'delete' => 'Drupal\workflows\Form\WorkflowDeleteForm', 'add-state' => 'Drupal\workflows\Form\WorkflowStateAddForm', 'edit-state' => 'Drupal\workflows\Form\WorkflowStateEditForm', 'delete-state' => 'Drupal\workflows\Form\WorkflowStateDeleteForm', 'add-transition' => 'Drupal\workflows\Form\WorkflowTransitionAddForm', 'edit-transition' => 'Drupal\workflows\Form\WorkflowTransitionEditForm', 'delete-transition' => 'Drupal\workflows\Form\WorkflowTransitionDeleteForm'], 'route_provider' => ['html' => 'Drupal\Core\Entity\Routing\AdminHtmlRouteProvider']], config_prefix: 'workflow', admin_permission: 'administer workflows', entity_keys: ['id' => 'id', 'label' => 'label', 'uuid' => 'uuid'], links: ['add-form' => '/admin/config/workflow/workflows/add', 'edit-form' => '/admin/config/workflow/workflows/manage/{workflow}', 'delete-form' => '/admin/config/workflow/workflows/manage/{workflow}/delete', 'add-state-form' => '/admin/config/workflow/workflows/manage/{workflow}/add_state', 'add-transition-form' => '/admin/config/workflow/workflows/manage/{workflow}/add_transition', 'collection' => '/admin/config/workflow/workflows'], config_export: ['id', 'label', 'type', 'type_settings'])]
 class Workflow extends ConfigEntityBase implements WorkflowInterface, EntityWithPluginCollectionInterface {
 
   /**

--- a/core/modules/workspaces/src/Entity/Workspace.php
+++ b/core/modules/workspaces/src/Entity/Workspace.php
@@ -13,57 +13,8 @@ use Drupal\workspaces\WorkspaceInterface;
 
 /**
  * The workspace entity class.
- *
- * @ContentEntityType(
- *   id = "workspace",
- *   label = @Translation("Workspace"),
- *   label_collection = @Translation("Workspaces"),
- *   label_singular = @Translation("workspace"),
- *   label_plural = @Translation("workspaces"),
- *   label_count = @PluralTranslation(
- *     singular = "@count workspace",
- *     plural = "@count workspaces"
- *   ),
- *   handlers = {
- *     "list_builder" = "\Drupal\workspaces\WorkspaceListBuilder",
- *     "view_builder" = "Drupal\workspaces\WorkspaceViewBuilder",
- *     "access" = "Drupal\workspaces\WorkspaceAccessControlHandler",
- *     "views_data" = "Drupal\views\EntityViewsData",
- *     "route_provider" = {
- *       "html" = "\Drupal\Core\Entity\Routing\AdminHtmlRouteProvider",
- *     },
- *     "form" = {
- *       "default" = "\Drupal\workspaces\Form\WorkspaceForm",
- *       "add" = "\Drupal\workspaces\Form\WorkspaceForm",
- *       "edit" = "\Drupal\workspaces\Form\WorkspaceForm",
- *       "delete" = "\Drupal\workspaces\Form\WorkspaceDeleteForm",
- *       "activate" = "\Drupal\workspaces\Form\WorkspaceActivateForm",
- *     },
- *   },
- *   admin_permission = "administer workspaces",
- *   base_table = "workspace",
- *   revision_table = "workspace_revision",
- *   data_table = "workspace_field_data",
- *   revision_data_table = "workspace_field_revision",
- *   field_ui_base_route = "entity.workspace.collection",
- *   entity_keys = {
- *     "id" = "id",
- *     "revision" = "revision_id",
- *     "uuid" = "uuid",
- *     "label" = "label",
- *     "uid" = "uid",
- *     "owner" = "uid",
- *   },
- *   links = {
- *     "canonical" = "/admin/config/workflow/workspaces/manage/{workspace}",
- *     "add-form" = "/admin/config/workflow/workspaces/add",
- *     "edit-form" = "/admin/config/workflow/workspaces/manage/{workspace}/edit",
- *     "delete-form" = "/admin/config/workflow/workspaces/manage/{workspace}/delete",
- *     "activate-form" = "/admin/config/workflow/workspaces/manage/{workspace}/activate",
- *     "collection" = "/admin/config/workflow/workspaces",
- *   },
- * )
  */
+#[\Drupal\Core\Entity\Attribute\ContentEntityType(id: 'workspace', label: new Drupal\Core\StringTranslation\TranslatableMarkup('Workspace'), label_collection: new Drupal\Core\StringTranslation\TranslatableMarkup('Workspaces'), label_singular: new Drupal\Core\StringTranslation\TranslatableMarkup('workspace'), label_plural: new Drupal\Core\StringTranslation\TranslatableMarkup('workspaces'), label_count: ['singular' => '@count workspace', 'plural' => '@count workspaces'], handlers: ['list_builder' => '\Drupal\workspaces\WorkspaceListBuilder', 'view_builder' => 'Drupal\workspaces\WorkspaceViewBuilder', 'access' => 'Drupal\workspaces\WorkspaceAccessControlHandler', 'views_data' => 'Drupal\views\EntityViewsData', 'route_provider' => ['html' => '\Drupal\Core\Entity\Routing\AdminHtmlRouteProvider'], 'form' => ['default' => '\Drupal\workspaces\Form\WorkspaceForm', 'add' => '\Drupal\workspaces\Form\WorkspaceForm', 'edit' => '\Drupal\workspaces\Form\WorkspaceForm', 'delete' => '\Drupal\workspaces\Form\WorkspaceDeleteForm', 'activate' => '\Drupal\workspaces\Form\WorkspaceActivateForm']], admin_permission: 'administer workspaces', base_table: 'workspace', revision_table: 'workspace_revision', data_table: 'workspace_field_data', revision_data_table: 'workspace_field_revision', field_ui_base_route: 'entity.workspace.collection', entity_keys: ['id' => 'id', 'revision' => 'revision_id', 'uuid' => 'uuid', 'label' => 'label', 'uid' => 'uid', 'owner' => 'uid'], links: ['canonical' => '/admin/config/workflow/workspaces/manage/{workspace}', 'add-form' => '/admin/config/workflow/workspaces/add', 'edit-form' => '/admin/config/workflow/workspaces/manage/{workspace}/edit', 'delete-form' => '/admin/config/workflow/workspaces/manage/{workspace}/delete', 'activate-form' => '/admin/config/workflow/workspaces/manage/{workspace}/activate', 'collection' => '/admin/config/workflow/workspaces'])]
 class Workspace extends ContentEntityBase implements WorkspaceInterface {
 
   use EntityChangedTrait;

--- a/core/rector.php
+++ b/core/rector.php
@@ -7,7 +7,8 @@ return static function(RectorConfig $rectorConfig): void {
   $rectorConfig->ruleWithConfiguration(\DrupalRector\Drupal10\Rector\Deprecation\AnnotationToAttributeRector::class, [
 
     // Setting remove version to 10.x means the comments are not kept.
-    new \DrupalRector\Drupal10\Rector\ValueObject\AnnotationToAttributeConfiguration('10.1.0', '10.0.0', 'Action', 'Drupal\Core\Action\Attribute\Action'),
+    new \DrupalRector\Drupal10\Rector\ValueObject\AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'ContentEntityType', 'Drupal\Core\Entity\Attribute\ContentEntityType'),
+    new \DrupalRector\Drupal10\Rector\ValueObject\AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'ConfigEntityType', 'Drupal\Core\Entity\Attribute\ConfigEntityType'),
   ]);
 
   $rectorConfig->autoloadPaths([


### PR DESCRIPTION
Added some small changes to rector. 

see: "palantirnet/drupal-rector": "dev-feature/annotation-configentitytype"

Rector config:

```
  $rectorConfig->ruleWithConfiguration(\DrupalRector\Drupal10\Rector\Deprecation\AnnotationToAttributeRector::class, [

    // Setting remove version to 10.x means the comments are not kept.
    new AnnotationToAttributeConfiguration('10.2.0', '12.0.0', 'ContentEntityType', 'Drupal\Core\Entity\Attribute\ConfigEntityType'),
  ]);
```